### PR TITLE
Refactor output handling to allow for settings append

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -577,7 +578,7 @@ func TestProcessSharedLibLine(t *testing.T) {
 		cfs.sharedLibResult = parseLineForSharedLibResult(c.lines[0])
 
 		prints := []string{}
-		printFn = func(format string, args ...interface{}) (int, error) {
+		printFn = func(_ io.Writer, format string, args ...interface{}) (int, error) {
 			prints = append(prints, fmt.Sprintf(format, args...))
 			return 0, nil
 		}
@@ -1028,7 +1029,7 @@ func TestProcessSettingsGroup(t *testing.T) {
 			}
 		}
 		numPrints := uint64(0)
-		printFn = func(format string, args ...interface{}) (int, error) {
+		printFn = func(_ io.Writer, format string, args ...interface{}) (int, error) {
 			numPrints++
 			return 0, nil
 		}
@@ -1078,7 +1079,7 @@ func TestProcessTunables(t *testing.T) {
 	mem := uint64(10 * parse.Gigabyte)
 	cpus := 6
 	oldPrintFn := printFn
-	printFn = func(_ string, _ ...interface{}) (int, error) {
+	printFn = func(_ io.Writer, _ string, _ ...interface{}) (int, error) {
 		return 0, nil
 	}
 
@@ -1137,7 +1138,7 @@ func TestProcessTunablesSingleCPU(t *testing.T) {
 	mem := uint64(10 * parse.Gigabyte)
 	cpus := 1
 	oldPrintFn := printFn
-	printFn = func(_ string, _ ...interface{}) (int, error) {
+	printFn = func(_ io.Writer, _ string, _ ...interface{}) (int, error) {
 		return 0, nil
 	}
 

--- a/print_test.go
+++ b/print_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
 
 type testPrinter struct {
 	statementCalls uint64
@@ -31,4 +36,100 @@ func (p *testPrinter) Success(format string, args ...interface{}) {
 func (p *testPrinter) Error(_ string, format string, args ...interface{}) {
 	p.errorCalls++
 	p.errors = append(p.errors, fmt.Sprintf(format, args...))
+}
+
+const whiteBoldSeq = "\x1b[37;1m"
+const purpleBoldSeq = "\x1b[35;1m"
+const greenBoldSeq = "\x1b[32;1m"
+const redBoldSeq = "\x1b[31;1m"
+const resetSeq = "\x1b[0m"
+
+func TestColorPrinterStatement(t *testing.T) {
+	var buf bytes.Buffer
+	p := &colorPrinter{&buf}
+	stmt := "This is a statement with %d"
+	p.Statement(stmt, 1)
+	want := whiteBoldSeq + fmt.Sprintf(stmt+"\n", 1) + resetSeq
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect statement: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestColorPrinterPrompt(t *testing.T) {
+	var buf bytes.Buffer
+	p := &colorPrinter{&buf}
+	stmt := "This is a prompt with %d"
+	p.Prompt(stmt, 1)
+	want := purpleBoldSeq + fmt.Sprintf(stmt, 1) + resetSeq
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect prompt: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestColorPrinterSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	p := &colorPrinter{&buf}
+	stmt := "This is a success with %d"
+	p.Success(stmt, 1)
+	want := greenBoldSeq + successLabel + resetSeq + fmt.Sprintf(stmt+"\n", 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect success: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestColorPrinterError(t *testing.T) {
+	var buf bytes.Buffer
+	p := &colorPrinter{&buf}
+	stmt := "This is a error with %d"
+	label := "yikes"
+	p.Error(label, stmt, 1)
+	want := redBoldSeq + label + ": " + resetSeq + fmt.Sprintf(stmt+"\n", 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestNoColorPrinterStatement(t *testing.T) {
+	var buf bytes.Buffer
+	p := &noColorPrinter{&buf}
+	stmt := "This is a statement with %d"
+	p.Statement(stmt, 1)
+	want := noColorPrefixStatement + fmt.Sprintf(stmt+"\n", 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect statement: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestNoColorPrinterPrompt(t *testing.T) {
+	var buf bytes.Buffer
+	p := &noColorPrinter{&buf}
+	stmt := "This is a prompt with %d"
+	p.Prompt(stmt, 1)
+	want := noColorPrefixPrompt + fmt.Sprintf(stmt, 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect prompt: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestNoColorPrinterSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	p := &noColorPrinter{&buf}
+	stmt := "This is a success with %d"
+	p.Success(stmt, 1)
+	want := strings.ToUpper(successLabel) + fmt.Sprintf(stmt+"\n", 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect success: got\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestNoColorPrinterError(t *testing.T) {
+	var buf bytes.Buffer
+	p := &noColorPrinter{&buf}
+	stmt := "This is a error with %d"
+	label := "yikes"
+	p.Error(label, stmt, 1)
+	want := strings.ToUpper(label) + ": " + fmt.Sprintf(stmt+"\n", 1)
+	if got := string(buf.Bytes()); got != want {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
+	}
 }


### PR DESCRIPTION
Some users may feel more comfortable or security settings may make
it better to simply append the updated settings to the end of the
configuration file. This PR therefore redirects much of the
informational output to stderr so it does not end up in the config
file (when using --quiet, --yes, and --dry-run).

Tests for the printers also added.