### PR TITLE
Refactor tstune.Tuner to improve test coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
Replace the call to os.Stat with a call to a global osStatFn var
instead so that a dummy function can be substituted in for testing.
Also, move the initialization of ioHandler into its own function
for testing.