### PR TITLE
Fix recommendations for parallelism in PG 9.6

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -21,6 +21,7 @@ var f tstune.TunerFlags
 func init() {
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")
+	flag.StringVar(&f.PGConfig, "pg-config", "pg_config", "Path to the pg_config binary")
 	flag.BoolVar(&f.YesAlways, "yes", false, "Answer 'yes' to every prompt")
 	flag.BoolVar(&f.Quiet, "quiet", false, "Show only the total recommendations at the end")
 	flag.BoolVar(&f.UseColor, "color", true, "Use color in output (works best on dark terminals)")

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -288,7 +288,7 @@ func TestParsePGFormatToBytes(t *testing.T) {
 		{
 			desc:   "incorrect format #5",
 			input:  tooBigInt + MB,
-			errMsg: fmt.Sprintf(errCouldNotParseFmt, tooBigErr),
+			errMsg: fmt.Sprintf(errCouldNotParseBytesFmt, tooBigErr),
 		},
 		{
 			desc:  "valid kilobytes",
@@ -349,5 +349,88 @@ func TestParsePGFormatToBytes(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestToPGMajorVersion(t *testing.T) {
+	okPrefix := "PostgreSQL "
+	cases := []struct {
+		desc    string
+		version string
+		want    string
+		errMsg  string
+	}{
+		{
+			desc:    "pg11",
+			version: okPrefix + "11.1",
+			want:    "11",
+		},
+		{
+			desc:    "pg11 w/ extra",
+			version: okPrefix + "11.1 (Debian)",
+			want:    "11",
+		},
+		{
+			desc:    "pg10",
+			version: okPrefix + "10.5",
+			want:    "10",
+		},
+		{
+			desc:    "pg10 w/ extra",
+			version: okPrefix + "10.2 (Debian)",
+			want:    "10",
+		},
+		{
+			desc:    "9.6",
+			version: okPrefix + "9.6.3",
+			want:    "9.6",
+		},
+
+		{
+			desc:    "9.5",
+			version: okPrefix + "9.5.9",
+			want:    "9.5",
+		},
+		{
+			desc:    "8.1",
+			version: okPrefix + "8.1.9",
+			want:    "8.1",
+		},
+		{
+			desc:    "7.3",
+			version: okPrefix + "7.3.9",
+			want:    "7.3",
+		},
+		{
+			desc:    "bad parse",
+			version: "10.0",
+			want:    "",
+			errMsg:  fmt.Sprintf(errCouldNotParseVersionFmt, "10.0"),
+		},
+		{
+			desc:    "old version",
+			version: "PostgreSQL 6.3.2",
+			want:    "",
+			errMsg:  fmt.Sprintf(errUnknownMajorVersionFmt, "PostgreSQL 6.3.2"),
+		},
+	}
+
+	for _, c := range cases {
+		got, err := ToPGMajorVersion(c.version)
+		if got != c.want {
+			t.Errorf("%s: incorrect version: got %s want %s", c.desc, got, c.want)
+		}
+		if len(c.errMsg) > 0 {
+			if err == nil {
+				t.Errorf("%s: unexpected lack of error", c.desc)
+			}
+			if got := err.Error(); got != c.errMsg {
+				t.Errorf("%s: incorrect error msg: got\n%s\nwant\n%s", c.desc, got, c.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.desc, err)
+			}
+		}
 	}
 }

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -197,7 +197,7 @@ func TestMemoryRecommenderRecommendPanic(t *testing.T) {
 func TestMemorySettingsGroup(t *testing.T) {
 	mem := uint64(1024)
 	cpus := 4
-	sg := GetSettingsGroup(MemoryLabel, mem, cpus)
+	sg := GetSettingsGroup(MemoryLabel, "10", mem, cpus)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != MemoryLabel {

--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -124,7 +124,7 @@ func TestMiscRecommenderRecommendPanic(t *testing.T) {
 func TestMiscSettingsGroup(t *testing.T) {
 	mem := uint64(1024)
 	cpus := 4
-	sg := GetSettingsGroup(MiscLabel, mem, cpus)
+	sg := GetSettingsGroup(MiscLabel, "10", mem, cpus)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != MiscLabel {

--- a/pkg/pgtune/parallel.go
+++ b/pkg/pgtune/parallel.go
@@ -9,7 +9,7 @@ import (
 const (
 	MaxWorkerProcessesKey       = "max_worker_processes"
 	MaxParallelWorkersGatherKey = "max_parallel_workers_per_gather"
-	MaxParallelWorkers          = "max_parallel_workers"
+	MaxParallelWorkers          = "max_parallel_workers" // pg10+
 
 	errOneCPU = "cannot make recommendations with just 1 CPU"
 )
@@ -59,14 +59,20 @@ func (r *ParallelRecommender) Recommend(key string) string {
 
 // ParallelSettingsGroup is the SettingsGroup to represent parallelism settings.
 type ParallelSettingsGroup struct {
-	cpus int
+	pgVersion string
+	cpus      int
 }
 
 // Label should always return the value ParallelLabel.
 func (sg *ParallelSettingsGroup) Label() string { return ParallelLabel }
 
 // Keys should always return the ParallelKeys slice.
-func (sg *ParallelSettingsGroup) Keys() []string { return ParallelKeys }
+func (sg *ParallelSettingsGroup) Keys() []string {
+	if sg.pgVersion == "9.6" {
+		return ParallelKeys[:2]
+	}
+	return ParallelKeys
+}
 
 // GetRecommender should return a new ParallelRecommender.
 func (sg *ParallelSettingsGroup) GetRecommender() Recommender {

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -130,25 +130,34 @@ func TestParallelRecommenderRecommendPanics(t *testing.T) {
 func TestParallelSettingsGroup(t *testing.T) {
 	mem := uint64(1024)
 	cpus := 4
-	sg := GetSettingsGroup(ParallelLabel, mem, cpus)
-	// no matter how many calls, all calls should return the same
-	for i := 0; i < 1000; i++ {
-		if got := sg.Label(); got != ParallelLabel {
-			t.Errorf("incorrect label: got %s want %s", got, ParallelLabel)
-		}
-		if got := sg.Keys(); got != nil {
-			for i, k := range got {
-				if k != ParallelKeys[i] {
-					t.Errorf("incorrect key at %d: got %s want %s", i, k, ParallelKeys[i])
-				}
+	checkFn := func(sg SettingsGroup) {
+		// no matter how many calls, all calls should return the same
+		for i := 0; i < 1000; i++ {
+			if got := sg.Label(); got != ParallelLabel {
+				t.Errorf("incorrect label: got %s want %s", got, ParallelLabel)
 			}
-		} else {
-			t.Errorf("keys is nil")
-		}
-		r := sg.GetRecommender().(*ParallelRecommender)
-		// the above will panic if not true
-		if r.cpus != cpus {
-			t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, cpus)
+			if got := sg.Keys(); got != nil {
+				for i, k := range got {
+					if k != ParallelKeys[i] {
+						t.Errorf("incorrect key at %d: got %s want %s", i, k, ParallelKeys[i])
+					}
+				}
+			} else {
+				t.Errorf("keys is nil")
+			}
+			r := sg.GetRecommender().(*ParallelRecommender)
+			// the above will panic if not true
+			if r.cpus != cpus {
+				t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, cpus)
+			}
 		}
 	}
+
+	sg := GetSettingsGroup(ParallelLabel, "9.6", mem, cpus)
+	checkFn(sg)
+
+	// PG10 adds a key
+	sg = GetSettingsGroup(ParallelLabel, "10", mem, cpus)
+	checkFn(sg)
+
 }

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -28,12 +28,12 @@ type SettingsGroup interface {
 
 // GetSettingsGroup returns the corresponding SettingsGroup for a given label, initialized
 // according to the system resources of totalMemory and cpus. Panics if unknown label.
-func GetSettingsGroup(label string, totalMemory uint64, cpus int) SettingsGroup {
+func GetSettingsGroup(label string, pgVersion string, totalMemory uint64, cpus int) SettingsGroup {
 	switch {
 	case label == MemoryLabel:
 		return &MemorySettingsGroup{totalMemory, cpus}
 	case label == ParallelLabel:
-		return &ParallelSettingsGroup{cpus}
+		return &ParallelSettingsGroup{pgVersion, cpus}
 	case label == WALLabel:
 		return &WALSettingsGroup{totalMemory}
 	case label == MiscLabel:

--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -6,8 +6,9 @@ func TestGetSettingsGroup(t *testing.T) {
 	okLabels := []string{MemoryLabel, ParallelLabel, WALLabel, MiscLabel}
 	mem := uint64(1024)
 	cpus := 4
+	pgVersion := "10"
 	for _, label := range okLabels {
-		sg := GetSettingsGroup(label, mem, cpus)
+		sg := GetSettingsGroup(label, pgVersion, mem, cpus)
 		if sg == nil {
 			t.Errorf("settings group unexpectedly nil for label %s", label)
 		}
@@ -19,6 +20,9 @@ func TestGetSettingsGroup(t *testing.T) {
 		case *ParallelSettingsGroup:
 			if x.cpus != cpus {
 				t.Errorf("parallel settings group incorrect: got %d want %d", x.cpus, cpus)
+			}
+			if x.pgVersion != pgVersion {
+				t.Errorf("parallel settings group incorrect: got %s want %s", x.pgVersion, pgVersion)
 			}
 		case *WALSettingsGroup:
 			if x.totalMemory != mem {
@@ -37,6 +41,6 @@ func TestGetSettingsGroup(t *testing.T) {
 				t.Errorf("did not panic when should")
 			}
 		}()
-		GetSettingsGroup("foo", mem, cpus)
+		GetSettingsGroup("foo", pgVersion, mem, cpus)
 	}()
 }

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -107,7 +107,7 @@ func TestWALRecommenderRecommendPanic(t *testing.T) {
 func TestWALSettingsGroup(t *testing.T) {
 	mem := uint64(1024)
 	cpus := 4
-	sg := GetSettingsGroup(WALLabel, mem, cpus)
+	sg := GetSettingsGroup(WALLabel, "10", mem, cpus)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != WALLabel {

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -59,6 +59,7 @@ func TestGetConfigFilePath(t *testing.T) {
 	cases := []struct {
 		desc      string
 		os        string
+		pgVersion string
 		files     []string
 		wantFile  string
 		shouldErr bool
@@ -80,6 +81,7 @@ func TestGetConfigFilePath(t *testing.T) {
 		{
 			desc:      "linux - pg10+debian",
 			os:        osLinux,
+			pgVersion: pgMajor10,
 			files:     []string{fmt.Sprintf(fileNameDebianFmt, "10")},
 			wantFile:  fmt.Sprintf(fileNameDebianFmt, "10"),
 			shouldErr: false,
@@ -87,13 +89,23 @@ func TestGetConfigFilePath(t *testing.T) {
 		{
 			desc:      "linux - pg9.6+debian",
 			os:        osLinux,
+			pgVersion: pgMajor96,
 			files:     []string{fmt.Sprintf(fileNameDebianFmt, "9.6")},
 			wantFile:  fmt.Sprintf(fileNameDebianFmt, "9.6"),
 			shouldErr: false,
 		},
 		{
+			desc:      "linux - mismatch+debian",
+			os:        osLinux,
+			pgVersion: pgMajor96,
+			files:     []string{fmt.Sprintf(fileNameDebianFmt, "10")},
+			wantFile:  "",
+			shouldErr: true,
+		},
+		{
 			desc:      "linux - pg10+rpm",
 			os:        osLinux,
+			pgVersion: pgMajor10,
 			files:     []string{fmt.Sprintf(fileNameRPMFmt, "10")},
 			wantFile:  fmt.Sprintf(fileNameRPMFmt, "10"),
 			shouldErr: false,
@@ -101,9 +113,19 @@ func TestGetConfigFilePath(t *testing.T) {
 		{
 			desc:      "linux - pg9.6+rpm",
 			os:        osLinux,
+			pgVersion: pgMajor96,
 			files:     []string{fmt.Sprintf(fileNameDebianFmt, "9.6")},
 			wantFile:  fmt.Sprintf(fileNameDebianFmt, "9.6"),
 			shouldErr: false,
+		},
+
+		{
+			desc:      "linux - mismatch+rpm",
+			os:        osLinux,
+			pgVersion: pgMajor96,
+			files:     []string{fmt.Sprintf(fileNameRPMFmt, "10")},
+			wantFile:  "",
+			shouldErr: true,
 		},
 		{
 			desc:      "linux - arch",
@@ -132,7 +154,7 @@ func TestGetConfigFilePath(t *testing.T) {
 			}
 			return nil, os.ErrNotExist
 		}
-		filename, err := getConfigFilePath(c.os)
+		filename, err := getConfigFilePath(c.os, c.pgVersion)
 		if err != nil && !c.shouldErr {
 			t.Errorf("%s: unexpected error: %v", c.desc, err)
 		} else if err == nil && c.shouldErr {

--- a/pkg/tstune/utils.go
+++ b/pkg/tstune/utils.go
@@ -1,0 +1,26 @@
+package tstune
+
+import (
+	"math"
+	"os/exec"
+)
+
+// isCloseEnough checks whether a provided value actual is within +/- the
+// fudge factor fudge of target.
+func isCloseEnough(actual, target, fudge float64) bool {
+	return math.Abs((target-actual)/target) <= fudge
+}
+
+// isIn checks whether a given string s is inside the []string arr.
+func isIn(s string, arr []string) bool {
+	for _, x := range arr {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}
+
+func getPGConfigVersion(binPath string) ([]byte, error) {
+	return exec.Command(binPath, "--version").Output()
+}

--- a/pkg/tstune/utils_test.go
+++ b/pkg/tstune/utils_test.go
@@ -1,0 +1,31 @@
+package tstune
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func TestIsIn(t *testing.T) {
+	limit := 1000
+	arr := []string{}
+	for i := 0; i < limit; i++ {
+		arr = append(arr, fmt.Sprintf("str%d", i))
+	}
+
+	// Should always be in the arr
+	for i := 0; i < limit*10; i++ {
+		s := fmt.Sprintf("str%d", rand.Intn(limit))
+		if !isIn(s, arr) {
+			t.Errorf("should be in the arr: %s", s)
+		}
+	}
+
+	// Should never be in the arr
+	for i := 0; i < limit*10; i++ {
+		s := fmt.Sprintf("str%d", limit+rand.Intn(limit))
+		if isIn(s, arr) {
+			t.Errorf("should not be in the arr: %s", s)
+		}
+	}
+}


### PR DESCRIPTION
PostgreSQL 9.6 does not support the max_parallel_workers option,
so the tool should not recommend adding or changing that setting
if being run on a 9.6 instance.

This requires using pg_config to detect which version of PG is
being run on the machine. Given the output of pg_config, we can
also simplify our look up logic for possible paths where the conf
file might exist.

This commit adds support for coverting PostgreSQL version strings
into different major versions which is then used by the tune tool.