### PR TITLE
Refactor system resources into type pgtune.SystemConfig

### DIFF
--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -195,9 +195,8 @@ func TestMemoryRecommenderRecommendPanic(t *testing.T) {
 }
 
 func TestMemorySettingsGroup(t *testing.T) {
-	mem := uint64(1024)
-	cpus := 4
-	sg := GetSettingsGroup(MemoryLabel, "10", mem, cpus)
+	config := NewSystemConfig(1024, 4, "10")
+	sg := GetSettingsGroup(MemoryLabel, config)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != MemoryLabel {
@@ -214,11 +213,11 @@ func TestMemorySettingsGroup(t *testing.T) {
 		}
 		r := sg.GetRecommender().(*MemoryRecommender)
 		// the above will panic if not true
-		if r.cpus != cpus {
-			t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, cpus)
+		if r.cpus != config.CPUs {
+			t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, config.CPUs)
 		}
-		if r.totalMemory != mem {
-			t.Errorf("recommender has wrong number of mem: got %d want %d", r.totalMemory, mem)
+		if r.totalMemory != config.Memory {
+			t.Errorf("recommender has wrong number of mem: got %d want %d", r.totalMemory, config.Memory)
 		}
 	}
 }

--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -122,9 +122,8 @@ func TestMiscRecommenderRecommendPanic(t *testing.T) {
 }
 
 func TestMiscSettingsGroup(t *testing.T) {
-	mem := uint64(1024)
-	cpus := 4
-	sg := GetSettingsGroup(MiscLabel, "10", mem, cpus)
+	config := NewSystemConfig(1024, 4, "10")
+	sg := GetSettingsGroup(MiscLabel, config)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != MiscLabel {

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -128,8 +128,7 @@ func TestParallelRecommenderRecommendPanics(t *testing.T) {
 }
 
 func TestParallelSettingsGroup(t *testing.T) {
-	mem := uint64(1024)
-	cpus := 4
+	config := NewSystemConfig(1024, 4, "9.6")
 	checkFn := func(sg SettingsGroup) {
 		// no matter how many calls, all calls should return the same
 		for i := 0; i < 1000; i++ {
@@ -147,17 +146,18 @@ func TestParallelSettingsGroup(t *testing.T) {
 			}
 			r := sg.GetRecommender().(*ParallelRecommender)
 			// the above will panic if not true
-			if r.cpus != cpus {
-				t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, cpus)
+			if r.cpus != config.CPUs {
+				t.Errorf("recommender has wrong number of cpus: got %d want %d", r.cpus, config.CPUs)
 			}
 		}
 	}
 
-	sg := GetSettingsGroup(ParallelLabel, "9.6", mem, cpus)
+	sg := GetSettingsGroup(ParallelLabel, config)
 	checkFn(sg)
 
 	// PG10 adds a key
-	sg = GetSettingsGroup(ParallelLabel, "10", mem, cpus)
+	config.PGMajorVersion = "10"
+	sg = GetSettingsGroup(ParallelLabel, config)
 	checkFn(sg)
 
 }

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -26,16 +26,33 @@ type SettingsGroup interface {
 	GetRecommender() Recommender
 }
 
+// SystemConfig represents a system's resource configuration, to be used when generating
+// recommendations for different SettingsGroups.
+type SystemConfig struct {
+	Memory         uint64
+	CPUs           int
+	PGMajorVersion string
+}
+
+// NewSystemConfig returns a new SystemConfig with the given parameters.
+func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string) *SystemConfig {
+	return &SystemConfig{
+		Memory:         totalMemory,
+		CPUs:           cpus,
+		PGMajorVersion: pgVersion,
+	}
+}
+
 // GetSettingsGroup returns the corresponding SettingsGroup for a given label, initialized
 // according to the system resources of totalMemory and cpus. Panics if unknown label.
-func GetSettingsGroup(label string, pgVersion string, totalMemory uint64, cpus int) SettingsGroup {
+func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 	switch {
 	case label == MemoryLabel:
-		return &MemorySettingsGroup{totalMemory, cpus}
+		return &MemorySettingsGroup{config.Memory, config.CPUs}
 	case label == ParallelLabel:
-		return &ParallelSettingsGroup{pgVersion, cpus}
+		return &ParallelSettingsGroup{config.PGMajorVersion, config.CPUs}
 	case label == WALLabel:
-		return &WALSettingsGroup{totalMemory}
+		return &WALSettingsGroup{config.Memory}
 	case label == MiscLabel:
 		return &MiscSettingsGroup{}
 	}

--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -1,32 +1,55 @@
 package pgtune
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestNewSystemConfig(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		mem := rand.Uint64()
+		cpus := rand.Intn(32)
+		pgVersion := "10"
+		if i%2 == 0 {
+			pgVersion = "9.6"
+		}
+
+		config := NewSystemConfig(mem, cpus, pgVersion)
+		if config.Memory != mem {
+			t.Errorf("incorrect memory: got %d want %d", config.Memory, mem)
+		}
+		if config.CPUs != cpus {
+			t.Errorf("incorrect cpus: got %d want %d", config.CPUs, cpus)
+		}
+		if config.PGMajorVersion != pgVersion {
+			t.Errorf("incorrect pg version: got %s want %s", config.PGMajorVersion, pgVersion)
+		}
+	}
+}
 
 func TestGetSettingsGroup(t *testing.T) {
 	okLabels := []string{MemoryLabel, ParallelLabel, WALLabel, MiscLabel}
-	mem := uint64(1024)
-	cpus := 4
-	pgVersion := "10"
+	config := NewSystemConfig(1024, 4, "10")
 	for _, label := range okLabels {
-		sg := GetSettingsGroup(label, pgVersion, mem, cpus)
+		sg := GetSettingsGroup(label, config)
 		if sg == nil {
 			t.Errorf("settings group unexpectedly nil for label %s", label)
 		}
 		switch x := sg.(type) {
 		case *MemorySettingsGroup:
-			if x.totalMemory != mem || x.cpus != cpus {
-				t.Errorf("memory settings group incorrect: got %d,%d want %d,%d", x.totalMemory, x.cpus, mem, cpus)
+			if x.totalMemory != config.Memory || x.cpus != config.CPUs {
+				t.Errorf("memory settings group incorrect: got %d,%d want %d,%d", x.totalMemory, x.cpus, config.Memory, config.CPUs)
 			}
 		case *ParallelSettingsGroup:
-			if x.cpus != cpus {
-				t.Errorf("parallel settings group incorrect: got %d want %d", x.cpus, cpus)
+			if x.cpus != config.CPUs {
+				t.Errorf("parallel settings group incorrect: got %d want %d", x.cpus, config.CPUs)
 			}
-			if x.pgVersion != pgVersion {
-				t.Errorf("parallel settings group incorrect: got %s want %s", x.pgVersion, pgVersion)
+			if x.pgVersion != config.PGMajorVersion {
+				t.Errorf("parallel settings group incorrect: got %s want %s", x.pgVersion, config.PGMajorVersion)
 			}
 		case *WALSettingsGroup:
-			if x.totalMemory != mem {
-				t.Errorf("WAL settings group incorrect: got %d want %d", x.totalMemory, mem)
+			if x.totalMemory != config.Memory {
+				t.Errorf("WAL settings group incorrect: got %d want %d", x.totalMemory, config.Memory)
 			}
 		case *MiscSettingsGroup:
 		default:
@@ -41,6 +64,6 @@ func TestGetSettingsGroup(t *testing.T) {
 				t.Errorf("did not panic when should")
 			}
 		}()
-		GetSettingsGroup("foo", pgVersion, mem, cpus)
+		GetSettingsGroup("foo", config)
 	}()
 }

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -105,9 +105,8 @@ func TestWALRecommenderRecommendPanic(t *testing.T) {
 }
 
 func TestWALSettingsGroup(t *testing.T) {
-	mem := uint64(1024)
-	cpus := 4
-	sg := GetSettingsGroup(WALLabel, "10", mem, cpus)
+	config := NewSystemConfig(1024, 4, "10")
+	sg := GetSettingsGroup(WALLabel, config)
 	// no matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != WALLabel {
@@ -125,8 +124,8 @@ func TestWALSettingsGroup(t *testing.T) {
 		r := sg.GetRecommender().(*WALRecommender)
 		// the above will panic if not true
 
-		if r.totalMemory != mem {
-			t.Errorf("recommender has wrong number of mem: got %d want %d", r.totalMemory, mem)
+		if r.totalMemory != config.Memory {
+			t.Errorf("recommender has wrong number of mem: got %d want %d", r.totalMemory, config.Memory)
 		}
 	}
 }


### PR DESCRIPTION
For the maintainability of interfaces it is going to be easier to
expand/modify a separate type containing all variables that may
affect pgtune settings rather than passing each one as a separate
argument to all the methods that need to know about them.