### PR TITLE
Allow user to override memory & CPU via flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Is this okay? [(y)es/(n)o]: y
 success: shared_preload_libraries will be updated
 
 Tune memory/parallelism/WAL and other settings?[(y)es/(n)o]: y
-Recommendations based on 8.00 GB of available memory and 4 CPUs
+Recommendations based on 8.00 GB of available memory and 4 CPUs for PostgreSQL 10
 
 Memory settings recommendations
 Current:
@@ -64,6 +64,11 @@ At the end, your `postgresql.conf` will be overwritten with the changes that you
 accepted from the prompts.
 
 #### Other invocations
+
+If you want recommendations for a specific amount of memory and/or CPUs:
+```bash
+$ timescaledb-tune --memory="4GB" --cpus=2
+```
 
 If you want to accept all recommendations, you can use `--yes`:
 ```bash

--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -19,6 +19,8 @@ var f tstune.TunerFlags
 
 // Parse args
 func init() {
+	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
+	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")
 	flag.StringVar(&f.PGConfig, "pg-config", "pg_config", "Path to the pg_config binary")

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -27,7 +27,7 @@ const (
 )
 
 const (
-	errIncorrectFormatFmt      = "incorrect format for '%s'"
+	errIncorrectFormatFmt      = "incorrect PostgreSQL bytes format: '%s'"
 	errCouldNotParseBytesFmt   = "could not parse bytes number: %v"
 	errCouldNotParseVersionFmt = "unable to parse PG version string: %s"
 	errUnknownMajorVersionFmt  = "unknown major PG version: %s"
@@ -94,8 +94,8 @@ func BytesToPGFormat(bytes uint64) string {
 }
 
 // PGFormatToBytes parses a string to match it to the PostgreSQL byte string format,
-// which is <float value><string suffix>, e.g., 10.0GB, 15.2MB, 20.5kB, etc.
-func PGFormatToBytes(val string) (float64, error) {
+// which is <int value><string suffix>, e.g., 10GB, 1520MB, 20kB, etc.
+func PGFormatToBytes(val string) (uint64, error) {
 	res := pgBytesRegex.FindStringSubmatch(val)
 	if len(res) != 3 {
 		return 0.0, fmt.Errorf(errIncorrectFormatFmt, val)
@@ -117,7 +117,7 @@ func PGFormatToBytes(val string) (float64, error) {
 	} else {
 		return 0, fmt.Errorf("unknown units: %s", units)
 	}
-	return float64(ret), nil
+	return ret, nil
 }
 
 // ToPGMajorVersion returns the major PostgreSQL version associated with a given

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -256,13 +256,13 @@ func TestBytesToPGFormat(t *testing.T) {
 	}
 }
 
-func TestParsePGFormatToBytes(t *testing.T) {
+func TestPGFormatToBytes(t *testing.T) {
 	tooBigInt := "9223372036854775808"
 	_, tooBigErr := strconv.ParseInt(tooBigInt, 10, 64)
 	cases := []struct {
 		desc   string
 		input  string
-		want   float64
+		want   uint64
 		errMsg string
 	}{
 		{
@@ -289,6 +289,11 @@ func TestParsePGFormatToBytes(t *testing.T) {
 			desc:   "incorrect format #5",
 			input:  tooBigInt + MB,
 			errMsg: fmt.Sprintf(errCouldNotParseBytesFmt, tooBigErr),
+		},
+		{
+			desc:   "incorrect format #6",
+			input:  "5.5" + MB, // decimal memory is a no-no
+			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "5.5"+MB),
 		},
 		{
 			desc:  "valid kilobytes",
@@ -345,7 +350,7 @@ func TestParsePGFormatToBytes(t *testing.T) {
 				t.Errorf("%s: unexpected err: got %v", c.desc, err)
 			}
 			if got := bytes; got != c.want {
-				t.Errorf("%s: incorrect bytes: got %f want %f", c.desc, got, c.want)
+				t.Errorf("%s: incorrect bytes: got %d want %d", c.desc, got, c.want)
 			}
 		}
 

--- a/pkg/tstune/tune_settings.go
+++ b/pkg/tstune/tune_settings.go
@@ -37,7 +37,8 @@ type floatParser interface {
 type bytesFloatParser struct{}
 
 func (v *bytesFloatParser) ParseFloat(s string) (float64, error) {
-	return parse.PGFormatToBytes(s)
+	temp, err := parse.PGFormatToBytes(s)
+	return float64(temp), err
 }
 
 type numericFloatParser struct{}


### PR DESCRIPTION
In case the default values of all the memory and all the CPU cores
is not what the user wants, these values can now be overridden with
the --memory and --cpus flags.