### PR TITLE
Add support for writing a backup to restore from

### DIFF
--- a/pkg/tstune/config_file.go
+++ b/pkg/tstune/config_file.go
@@ -5,21 +5,32 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
+	"time"
 )
 
 const (
-	osMac                = "darwin"
-	osLinux              = "linux"
-	fileNameMac          = "/usr/local/var/postgres/postgresql.conf"
-	fileNameDebianFmt    = "/etc/postgresql/%s/main/postgresql.conf"
-	fileNameRPMFmt       = "/var/lib/pgsql/%s/data/postgresql.conf"
-	fileNameArch         = "/var/lib/postgres/data/postgresql.conf"
-	errConfigNotFoundFmt = "could not find postgresql.conf at any of these locations:\n%v"
+	osMac   = "darwin"
+	osLinux = "linux"
+
+	fileNameMac       = "/usr/local/var/postgres/postgresql.conf"
+	fileNameDebianFmt = "/etc/postgresql/%s/main/postgresql.conf"
+	fileNameRPMFmt    = "/var/lib/pgsql/%s/data/postgresql.conf"
+	fileNameArch      = "/var/lib/postgres/data/postgresql.conf"
+
+	errConfigNotFoundFmt   = "could not find postgresql.conf at any of these locations:\n%v"
+	errBackupNotCreatedFmt = "could not create backup at %s: %v"
+
+	backupFilePrefix = "timescaledb_tune.backup"
+	backupDateFmt    = "200601021504"
 )
 
 // allows us to substitute mock versions in tests
 var osStatFn = os.Stat
+var osCreateFn = func(path string) (io.Writer, error) {
+	return os.Create(path)
+}
 
 // fileExists is a simple check for stating if a file exists and if any error
 // occurs it returns false.
@@ -117,6 +128,19 @@ func getConfigFileState(r io.Reader) (*configFileState, error) {
 		i++
 	}
 	return cfs, nil
+}
+
+// Backup writes the conf file state to the system's temporary directory
+// with a well known name format so it can potentially be restored.
+func (cfs *configFileState) Backup() (string, error) {
+	backupName := backupFilePrefix + time.Now().Format(backupDateFmt)
+	backupPath := path.Join(os.TempDir(), backupName)
+	bf, err := osCreateFn(backupPath)
+	if err != nil {
+		return backupPath, fmt.Errorf(errBackupNotCreatedFmt, backupPath, err)
+	}
+	_, err = cfs.WriteTo(bf)
+	return backupPath, err
 }
 
 func (cfs *configFileState) WriteTo(w io.Writer) (int64, error) {

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -1,11 +1,15 @@
 package tstune
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
+	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/timescale/timescaledb-tune/pkg/pgtune"
 )
@@ -322,6 +326,61 @@ func (w *testWriter) Write(buf []byte) (int, error) {
 	}
 	w.lines = append(w.lines, string(buf))
 	return 0, nil
+}
+
+func TestConfigFileStateBackup(t *testing.T) {
+	oldOSCreateFn := osCreateFn
+	now := time.Now()
+	lines := []string{"foo", "bar", "baz", "quaz"}
+	cfs := &configFileState{lines: lines}
+	wantFileName := backupFilePrefix + now.Format(backupDateFmt)
+	wantPath := path.Join(os.TempDir(), wantFileName)
+
+	osCreateFn = func(_ string) (io.Writer, error) {
+		return nil, fmt.Errorf("erroring")
+	}
+
+	path, err := cfs.Backup()
+	if path != wantPath {
+		t.Errorf("incorrect path in error case: got\n%s\nwant\n%s", path, wantPath)
+	}
+	if err == nil {
+		t.Errorf("unexpected lack of error for bad create")
+	}
+	want := fmt.Sprintf(errBackupNotCreatedFmt, wantPath, "erroring")
+	if got := err.Error(); got != want {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
+	}
+
+	var buf bytes.Buffer
+	osCreateFn = func(p string) (io.Writer, error) {
+		if p != wantPath {
+			t.Errorf("incorrect backup path: got %s want %s", p, wantPath)
+		}
+		return &buf, nil
+	}
+	path, err = cfs.Backup()
+	if path != wantPath {
+		t.Errorf("incorrect path in correct case: got\n%s\nwant\n%s", path, wantPath)
+	}
+	if err != nil {
+		t.Errorf("unexpected error for backup: %v", err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(buf.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if scanner.Err() != nil {
+			t.Errorf("unexpected error while scanning: %v", scanner.Err())
+		}
+		got := scanner.Text()
+		if want := lines[i]; got != want {
+			t.Errorf("incorrect line at %d: got\n%s\nwant\n%s", i, got, want)
+		}
+		i++
+	}
+
+	osCreateFn = oldOSCreateFn
 }
 
 func TestConfigFileStateWriteTo(t *testing.T) {

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1266,7 +1266,7 @@ var (
 )
 
 func TestTunerProcessQuiet(t *testing.T) {
-	lastTuned := fmt.Sprintf(fmtLastTuned, time.Now().Format(dateFmt))
+	lastTuned := fmt.Sprintf(fmtLastTuned, time.Now().Format(lastTunedDateFmt))
 	cases := []struct {
 		desc          string
 		lines         []string


### PR DESCRIPTION
Since we are making changes to a user's configuration, we want to
be careful and let them have a way of restoring the old version in
case something goes wrong. In the future we could handle this
restore process via the tool as well.