### PR TITLE
Change last_tuned timestamp to be more precise

### DIFF
--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -49,8 +49,7 @@ const (
 	fmtTunableParam = "%s = %s%s\n"
 	fmtLastTuned    = "timescaledb.last_tuned = '%s'"
 
-	lastTunedDateFmt = "2006-01-02 15:04"
-	fudgeFactor      = 0.05
+	fudgeFactor = 0.05
 
 	pgMajor96 = "9.6"
 	pgMajor10 = "10"
@@ -217,7 +216,7 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 	}
 
 	// Append the current time to mark when database was last tuned
-	lastTunedLine := fmt.Sprintf(fmtLastTuned, time.Now().Format(lastTunedDateFmt))
+	lastTunedLine := fmt.Sprintf(fmtLastTuned, time.Now().Format(time.RFC3339))
 	cfs.lines = append(cfs.lines, lastTunedLine)
 
 	// Wrap up: Either write it out, or show success in --dry-run
@@ -525,7 +524,7 @@ func (t *Tuner) processQuiet(config *pgtune.SystemConfig) error {
 		return err
 	}
 	if changedSettings > 0 {
-		printFn(os.Stdout, fmtLastTuned+"\n", time.Now().Format(lastTunedDateFmt))
+		printFn(os.Stdout, fmtLastTuned+"\n", time.Now().Format(time.RFC3339))
 		checker := newYesNoChecker("not using these settings could lead to suboptimal performance")
 		err = t.promptUntilValidInput("Use these recommendations? "+promptYesNo, checker)
 		if err != nil {

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1266,7 +1266,11 @@ var (
 )
 
 func TestTunerProcessQuiet(t *testing.T) {
-	lastTuned := fmt.Sprintf(fmtLastTuned, time.Now().Format(lastTunedDateFmt))
+	// We should only expect the first part of the timestamps to be the same,
+	// since the number of seconds + milliseconds will change on each invocation
+	// inside the function (which we cannot control). Therefore, only compare a defined prefix.
+	timeMatchIdx := len("timescaledb.last_tuned = '") + 16
+	lastTuned := fmt.Sprintf(fmtLastTuned, time.Now().Format(time.RFC3339))[:timeMatchIdx]
 	cases := []struct {
 		desc          string
 		lines         []string
@@ -1362,8 +1366,8 @@ func TestTunerProcessQuiet(t *testing.T) {
 					t.Errorf("%s: incorrect print at idx %d: got\n%s\nwant\n%s", c.desc, i, got, want+"\n")
 				}
 			}
-			if got := prints[len(c.wantedPrints)]; got != lastTuned+"\n" {
-				t.Errorf("%s: lastTuned print is missing: got\n%s\nwant\n%s", c.desc, got, lastTuned+"\n")
+			if got := prints[len(c.wantedPrints)][:timeMatchIdx]; got != lastTuned {
+				t.Errorf("%s: lastTuned print is missing/incorrect: got\n%s\nwant\n%s", c.desc, got, lastTuned+"\n")
 			}
 		}
 


### PR DESCRIPTION
This timestamp will be stored in telemetry, so having the full
timestamp with timezone information helps us store it naturally in
the TimescaleDB database.