### PR TITLE
Add last_tuned_version GUC to be written to modified conf files

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	binName = "timescaledb-tune"
-	version = "0.1.0"
+	version = tstune.Version
 )
 
 var (

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -19,6 +19,9 @@ import (
 )
 
 const (
+	// Version is the version of this library
+	Version = "0.2.0-dev"
+
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"
 
@@ -46,8 +49,9 @@ const (
 
 	successQuiet = "all settings tuned, no changes needed"
 
-	fmtTunableParam = "%s = %s%s\n"
-	fmtLastTuned    = "timescaledb.last_tuned = '%s'"
+	fmtTunableParam     = "%s = %s%s\n"
+	fmtLastTuned        = "timescaledb.last_tuned = '%s'"
+	fmtLastTunedVersion = "timescaledb.last_tuned_version = '%s'"
 
 	fudgeFactor = 0.05
 
@@ -217,7 +221,8 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 
 	// Append the current time to mark when database was last tuned
 	lastTunedLine := fmt.Sprintf(fmtLastTuned, time.Now().Format(time.RFC3339))
-	cfs.lines = append(cfs.lines, lastTunedLine)
+	lastTunedVersionLine := fmt.Sprintf(fmtLastTunedVersion, Version)
+	cfs.lines = append(cfs.lines, lastTunedLine, lastTunedVersionLine)
 
 	// Wrap up: Either write it out, or show success in --dry-run
 	if !t.flags.DryRun {
@@ -525,6 +530,7 @@ func (t *Tuner) processQuiet(config *pgtune.SystemConfig) error {
 	}
 	if changedSettings > 0 {
 		printFn(os.Stdout, fmtLastTuned+"\n", time.Now().Format(time.RFC3339))
+		printFn(os.Stdout, fmtLastTunedVersion+"\n", Version)
 		checker := newYesNoChecker("not using these settings could lead to suboptimal performance")
 		err = t.promptUntilValidInput("Use these recommendations? "+promptYesNo, checker)
 		if err != nil {


### PR DESCRIPTION
In the future, it may be useful to determine with which version of
timescaledb-tune a conf file has been tuned with. TimescaleDB or
another program can use this GUC to prompt the user to re-run the
tuning program again if there are new updates/changes.