### PR TITLE
Fix pgtune.GetSettingsGroup to pass on memory to MiscSettings

### DIFF
--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/timescale/timescaledb-tune/internal/parse"
 )
 
+var memSettingsMatrix = map[uint64]map[string]string{
+	7 * parse.Gigabyte:  map[string]string{MaxLocksPerTx: maxLocksValues[0]},
+	8 * parse.Gigabyte:  map[string]string{MaxLocksPerTx: maxLocksValues[1]},
+	15 * parse.Gigabyte: map[string]string{MaxLocksPerTx: maxLocksValues[1]},
+	16 * parse.Gigabyte: map[string]string{MaxLocksPerTx: maxLocksValues[2]},
+	24 * parse.Gigabyte: map[string]string{MaxLocksPerTx: maxLocksValues[2]},
+	32 * parse.Gigabyte: map[string]string{MaxLocksPerTx: maxLocksValues[3]},
+	80 * parse.Gigabyte: map[string]string{MaxLocksPerTx: maxLocksValues[3]},
+}
+
+func init() {
+	for level := range memSettingsMatrix {
+		memSettingsMatrix[level][CheckpointKey] = checkpointDefault
+		memSettingsMatrix[level][StatsTargetKey] = statsTargetDefault
+		memSettingsMatrix[level][MaxConnectionsKey] = maxConnectionsDefault
+		memSettingsMatrix[level][RandomPageCostKey] = randomPageCostDefault
+		memSettingsMatrix[level][EffectiveIOKey] = effectiveIODefault
+	}
+}
+
 func TestNewMiscRecommender(t *testing.T) {
 	for i := 0; i < 1000000; i++ {
 		mem := rand.Uint64()
@@ -25,86 +45,12 @@ func TestNewMiscRecommender(t *testing.T) {
 }
 
 func TestMiscRecommenderRecommend(t *testing.T) {
-	cases := []struct {
-		desc        string
-		totalMemory uint64
-		key         string
-		want        string
-	}{
-		{
-			desc: CheckpointKey,
-			key:  CheckpointKey,
-			want: checkpointDefault,
-		},
-		{
-			desc: StatsTargetKey,
-			key:  StatsTargetKey,
-			want: statsTargetDefault,
-		},
-		{
-			desc: MaxConnectionsKey,
-			key:  MaxConnectionsKey,
-			want: maxConnectionsDefault,
-		},
-		{
-			desc: RandomPageCostKey,
-			key:  RandomPageCostKey,
-			want: randomPageCostDefault,
-		},
-		{
-			desc:        MaxLocksPerTx + " < 8gb",
-			totalMemory: 7 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[0],
-		},
-		{
-			desc:        MaxLocksPerTx + " = 8gb",
-			totalMemory: 8 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[1],
-		},
-		{
-			desc:        MaxLocksPerTx + " > 8gb, < 16GB",
-			totalMemory: 15 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[1],
-		},
-		{
-			desc:        MaxLocksPerTx + " = 16GB",
-			totalMemory: 16 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[2],
-		},
-		{
-			desc:        MaxLocksPerTx + " > 16gb, < 32GB",
-			totalMemory: 24 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[2],
-		},
-		{
-			desc:        MaxLocksPerTx + " = 32GB",
-			totalMemory: 32 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[3],
-		},
-		{
-			desc:        MaxLocksPerTx + " > 32gb",
-			totalMemory: 80 * parse.Gigabyte,
-			key:         MaxLocksPerTx,
-			want:        maxLocksValues[3],
-		},
-		{
-			desc: EffectiveIOKey,
-			key:  EffectiveIOKey,
-			want: effectiveIODefault,
-		},
-	}
-
-	for _, c := range cases {
-		r := &MiscRecommender{c.totalMemory}
-		got := r.Recommend(c.key)
-		if got != c.want {
-			t.Errorf("%s: incorrect result: got\n%s\nwant\n%s", c.desc, got, c.want)
+	for totalMemory, kvs := range memSettingsMatrix {
+		r := &MiscRecommender{totalMemory}
+		for key, want := range kvs {
+			if got := r.Recommend(key); got != want {
+				t.Errorf("%d-%s: incorrect result: got\n%s\nwant\n%s", totalMemory, key, got, want)
+			}
 		}
 	}
 }
@@ -122,23 +68,31 @@ func TestMiscRecommenderRecommendPanic(t *testing.T) {
 }
 
 func TestMiscSettingsGroup(t *testing.T) {
-	config := NewSystemConfig(1024, 4, "10")
-	sg := GetSettingsGroup(MiscLabel, config)
-	// no matter how many calls, all calls should return the same
-	for i := 0; i < 1000; i++ {
-		if got := sg.Label(); got != MiscLabel {
-			t.Errorf("incorrect label: got %s want %s", got, MiscLabel)
-		}
-		if got := sg.Keys(); got != nil {
-			for i, k := range got {
-				if k != MiscKeys[i] {
-					t.Errorf("incorrect key at %d: got %s want %s", i, k, MiscKeys[i])
+	for totalMemory, kvs := range memSettingsMatrix {
+		config := NewSystemConfig(totalMemory, 8, "10")
+		sg := GetSettingsGroup(MiscLabel, config)
+		// no matter how many calls, all calls should return the same
+		for i := 0; i < 1000; i++ {
+			if got := sg.Label(); got != MiscLabel {
+				t.Errorf("incorrect label: got %s want %s", got, MiscLabel)
+			}
+			if got := sg.Keys(); got != nil {
+				for i, k := range got {
+					if k != MiscKeys[i] {
+						t.Errorf("incorrect key at %d: got %s want %s", i, k, MiscKeys[i])
+					}
+				}
+			} else {
+				t.Errorf("keys is nil")
+			}
+			r := sg.GetRecommender().(*MiscRecommender)
+			// the above will panic if not true
+
+			for key, want := range kvs {
+				if got := r.Recommend(key); got != want {
+					t.Errorf("%d-%s: incorrect result: got\n%s\nwant\n%s", totalMemory, key, got, want)
 				}
 			}
-		} else {
-			t.Errorf("keys is nil")
 		}
-		_ = sg.GetRecommender().(*MiscRecommender)
-		// the above will panic if not true
 	}
 }

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -54,7 +54,7 @@ func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 	case label == WALLabel:
 		return &WALSettingsGroup{config.Memory}
 	case label == MiscLabel:
-		return &MiscSettingsGroup{}
+		return &MiscSettingsGroup{config.Memory}
 	}
 	panic("unknown label: " + label)
 }

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1262,6 +1262,7 @@ var (
 		"max_connections = 20",
 		"max_locks_per_transaction = 64",
 		"effective_io_concurrency = 200",
+		"max_locks_per_transaction = 128",
 	}
 )
 


### PR DESCRIPTION
MiscSettings uses total memory to determine the max number of
locks per transaction, but the memory was not being properly
passed on. This resulted in the tuning result always returning the
default amount of 64.