### PR TITLE
Refactor tests for pkg/pgtune for maintainability

### DIFF
--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -67,3 +67,32 @@ func TestGetSettingsGroup(t *testing.T) {
 		GetSettingsGroup("foo", config)
 	}()
 }
+
+func testSettingGroup(t *testing.T, sg SettingsGroup, cases map[string]string, wantLabel string, wantKeys []string) {
+	// No matter how many calls, all calls should return the same
+	for i := 0; i < 1000; i++ {
+		if got := sg.Label(); got != wantLabel {
+			t.Errorf("incorrect label: got %s want %s", got, wantLabel)
+		}
+		if got := sg.Keys(); got != nil {
+			for i, k := range got {
+				if k != wantKeys[i] {
+					t.Errorf("incorrect key at %d: got %s want %s", i, k, wantKeys[i])
+				}
+			}
+		} else {
+			t.Errorf("keys is nil")
+		}
+		r := sg.GetRecommender()
+
+		testRecommender(t, r, cases)
+	}
+}
+
+func testRecommender(t *testing.T, r Recommender, cases map[string]string) {
+	for key, want := range cases {
+		if got := r.Recommend(key); got != want {
+			t.Errorf("incorrect result for key %s: got\n%s\nwant\n%s", key, got, want)
+		}
+	}
+}

--- a/pkg/pgtune/wal.go
+++ b/pkg/pgtune/wal.go
@@ -14,8 +14,8 @@ const (
 
 	walBuffersThreshold = 2 * parse.Gigabyte
 	walBuffersDefault   = 16 * parse.Megabyte
-	minWalBytes         = 4 * parse.Gigabyte
-	maxWalBytes         = 8 * parse.Gigabyte
+	minWALBytes         = 4 * parse.Gigabyte
+	maxWALBytes         = 8 * parse.Gigabyte
 )
 
 // WALLabel is the label used to refer to the WAL settings group
@@ -56,9 +56,9 @@ func (r *WALRecommender) Recommend(key string) string {
 			val = parse.BytesToPGFormat(walBuffersDefault)
 		}
 	} else if key == MinWALKey {
-		val = parse.BytesToPGFormat(minWalBytes)
+		val = parse.BytesToPGFormat(minWALBytes)
 	} else if key == MaxWALKey {
-		val = parse.BytesToPGFormat(maxWalBytes)
+		val = parse.BytesToPGFormat(maxWALBytes)
 	} else {
 		panic(fmt.Sprintf("unknown key: %s", key))
 	}


### PR DESCRIPTION
The updates to pgtune.MiscSettingsGroup's tests provide a good
template to do for other SettingsGroups for more thorough coverage.
While adding this support, it simplifies the test functions to be
of the same form for most SettingsGroup so it can be furthered
refactored, leaving less bespoke code for each and making the whole
thing more maintainable.

Tests for MemorySettingsGroup will be done in a separate PR as its
test cases are less amenable to the simplified structure for the
others.