### PR TITLE
Refactor pgtune.MemorySettings tests for maintainability

### DIFF
--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/timescale/timescaledb-tune/internal/parse"
 )
 
+// miscSettingsMatrix stores the test cases for MiscRecommender along with the
+// expected values for its keys
 var miscSettingsMatrix = map[uint64]map[string]string{
 	7 * parse.Gigabyte:  map[string]string{MaxLocksPerTx: maxLocksValues[0]},
 	8 * parse.Gigabyte:  map[string]string{MaxLocksPerTx: maxLocksValues[1]},

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// parallelSettingsMatrix stores the test cases for ParallelRecommender along
+// with the expected values for its keys
 var parallelSettingsMatrix = map[int]map[string]string{
 	2: map[string]string{
 		MaxWorkerProcessesKey:       "2",

--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -92,7 +92,7 @@ func testSettingGroup(t *testing.T, sg SettingsGroup, cases map[string]string, w
 func testRecommender(t *testing.T, r Recommender, cases map[string]string) {
 	for key, want := range cases {
 		if got := r.Recommend(key); got != want {
-			t.Errorf("incorrect result for key %s: got\n%s\nwant\n%s", key, got, want)
+			t.Errorf("%v: incorrect result for key %s: got\n%s\nwant\n%s", r, key, got, want)
 		}
 	}
 }


### PR DESCRIPTION
This PR settles on 3 different memory levels to test along with
3 CPU levels to test, for a total of 9 test cases for memory. This
method brings it in line with the other SettingsGroups in the
package and makes it simpler to maintain going forward.

Windows test cases are still handled separately.