### PR TITLE
Add --restore flag

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -38,6 +38,7 @@ func init() {
 	flag.BoolVar(&f.Quiet, "quiet", false, "Show only the total recommendations at the end")
 	flag.BoolVar(&f.UseColor, "color", true, "Use color in output (works best on dark terminals)")
 	flag.BoolVar(&f.DryRun, "dry-run", false, "Whether to just show the changes without overwriting the configuration file")
+	flag.BoolVar(&f.Restore, "restore", false, "Whether to restore a previously made conf file backup")
 
 	flag.BoolVar(&showVersion, "version", false, "Show the version of this tool")
 	flag.Parse()

--- a/internal/parse/time.go
+++ b/internal/parse/time.go
@@ -1,0 +1,33 @@
+package parse
+
+import (
+	"fmt"
+	"time"
+)
+
+const lessThanMin = "less than a minute"
+
+// PrettyDuration returns a human-readable duration that should fit the
+// phrase "X ago", e.g., "less than a minute ago", "2 minutes ago", etc.
+func PrettyDuration(d time.Duration) string {
+	if d < time.Minute {
+		return lessThanMin
+	} else if d < time.Hour {
+		mins := int64(d.Minutes())
+		ending := ""
+		if mins > 1 {
+			ending = "s"
+		}
+		return fmt.Sprintf("%d minute%s", mins, ending)
+	} else if d < 48*time.Hour {
+		hrs := int64(d.Hours())
+		ending := ""
+		if hrs > 1 {
+			ending = "s"
+		}
+		return fmt.Sprintf("%d hour%s", hrs, ending)
+	}
+
+	days := int64(d.Hours()) / 24
+	return fmt.Sprintf("%d days", days)
+}

--- a/internal/parse/time_test.go
+++ b/internal/parse/time_test.go
@@ -1,0 +1,66 @@
+package parse
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPrettyDuration(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		given time.Time
+		want  string
+	}{
+		{
+			given: now,
+			want:  lessThanMin,
+		},
+		{
+			given: now.Add(59 * time.Second),
+			want:  lessThanMin,
+		},
+		{
+			given: now.Add(60 * time.Second),
+			want:  "1 minute",
+		},
+		{
+			given: now.Add(61 * time.Second),
+			want:  "1 minute",
+		},
+		{
+			given: now.Add(2 * time.Minute),
+			want:  "2 minutes",
+		},
+		{
+			given: now.Add(59 * time.Minute),
+			want:  "59 minutes",
+		},
+		{
+			given: now.Add(60 * time.Minute),
+			want:  "1 hour",
+		},
+		{
+			given: now.Add(61 * time.Minute),
+			want:  "1 hour",
+		},
+		{
+			given: now.Add(2 * time.Hour),
+			want:  "2 hours",
+		},
+		{
+			given: now.Add(47 * time.Hour),
+			want:  "47 hours",
+		},
+		{
+			given: now.Add(48 * time.Hour),
+			want:  "2 days",
+		},
+	}
+
+	for _, c := range cases {
+		d := c.given.Sub(now)
+		if got := PrettyDuration(d); got != c.want {
+			t.Errorf("incorrect value for %v: got\n%s\nwant\n%s", c.given, got, c.want)
+		}
+	}
+}

--- a/pkg/tstune/backup.go
+++ b/pkg/tstune/backup.go
@@ -1,0 +1,100 @@
+package tstune
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	backupFilePrefix = "timescaledb_tune.backup"
+	backupDateFmt    = "200601021504"
+
+	errBackupNotCreatedFmt = "could not create backup at %s: %v"
+)
+
+// allows us to substitute mock versions in tests
+var filepathGlobFn = filepath.Glob
+var osCreateFn = func(path string) (io.Writer, error) {
+	return os.Create(path)
+}
+
+// backup writes the conf file state to the system's temporary directory
+// with a well known name format so it can potentially be restored.
+func backup(cfs *configFileState) (string, error) {
+	backupName := backupFilePrefix + time.Now().Format(backupDateFmt)
+	backupPath := path.Join(os.TempDir(), backupName)
+	bf, err := osCreateFn(backupPath)
+	if err != nil {
+		return backupPath, fmt.Errorf(errBackupNotCreatedFmt, backupPath, err)
+	}
+	_, err = cfs.WriteTo(bf)
+	return backupPath, err
+}
+
+// getBackups returns a list of files that match timescaledb-tune's backup
+// filename format.
+func getBackups() ([]string, error) {
+	backupPattern := path.Join(os.TempDir(), backupFilePrefix+"*")
+	files, err := filepathGlobFn(backupPattern)
+	if err != nil {
+		return nil, err
+	}
+	ret := []string{}
+	stripPrefix := path.Join(os.TempDir(), backupFilePrefix)
+	for _, f := range files {
+		datePart := strings.Replace(f, stripPrefix, "", -1)
+		_, err := time.Parse(backupDateFmt, datePart)
+		if err != nil {
+			continue
+		}
+		ret = append(ret, f)
+	}
+	return ret, nil
+}
+
+type restorer interface {
+	Restore(string, string) error
+}
+
+type fsRestorer struct{}
+
+func (r *fsRestorer) Restore(backupPath, confPath string) error {
+	backupFile, err := os.Open(backupPath)
+	if err != nil {
+		return err
+	}
+	defer backupFile.Close()
+
+	backupCFS, err := getConfigFileState(backupFile)
+	if err != nil {
+		return err
+	}
+
+	confFile, err := os.OpenFile(confPath, os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer confFile.Close()
+
+	// in case new file is shorter than old, need to truncate first
+	err = confFile.Truncate(0)
+	if err != nil {
+		return err
+	}
+	_, err = confFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	_, err = backupCFS.WriteTo(confFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/tstune/backup_test.go
+++ b/pkg/tstune/backup_test.go
@@ -1,0 +1,196 @@
+package tstune
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestBackup(t *testing.T) {
+	oldOSCreateFn := osCreateFn
+	now := time.Now()
+	lines := []string{"foo", "bar", "baz", "quaz"}
+	cfs := &configFileState{lines: lines}
+	wantFileName := backupFilePrefix + now.Format(backupDateFmt)
+	wantPath := path.Join(os.TempDir(), wantFileName)
+
+	osCreateFn = func(_ string) (io.Writer, error) {
+		return nil, fmt.Errorf("erroring")
+	}
+
+	path, err := backup(cfs)
+	if path != wantPath {
+		t.Errorf("incorrect path in error case: got\n%s\nwant\n%s", path, wantPath)
+	}
+	if err == nil {
+		t.Errorf("unexpected lack of error for bad create")
+	}
+	want := fmt.Sprintf(errBackupNotCreatedFmt, wantPath, "erroring")
+	if got := err.Error(); got != want {
+		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
+	}
+
+	var buf bytes.Buffer
+	osCreateFn = func(p string) (io.Writer, error) {
+		if p != wantPath {
+			t.Errorf("incorrect backup path: got %s want %s", p, wantPath)
+		}
+		return &buf, nil
+	}
+	path, err = backup(cfs)
+	if path != wantPath {
+		t.Errorf("incorrect path in correct case: got\n%s\nwant\n%s", path, wantPath)
+	}
+	if err != nil {
+		t.Errorf("unexpected error for backup: %v", err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(buf.Bytes()))
+	i := 0
+	for scanner.Scan() {
+		if scanner.Err() != nil {
+			t.Errorf("unexpected error while scanning: %v", scanner.Err())
+		}
+		got := scanner.Text()
+		if want := lines[i]; got != want {
+			t.Errorf("incorrect line at %d: got\n%s\nwant\n%s", i, got, want)
+		}
+		i++
+	}
+
+	osCreateFn = oldOSCreateFn
+}
+
+func TestGetBackups(t *testing.T) {
+	errGlob := "glob error"
+	correctFile1 := path.Join(os.TempDir(), "timescaledb_tune.backup201901181122")
+	correctFile2 := path.Join(os.TempDir(), "timescaledb_tune.backup201901191200")
+	cases := []struct {
+		desc        string
+		onDiskFiles []string
+		globErr     bool
+		want        []string
+		errMsg      string
+	}{
+		{
+			desc:        "error on glob",
+			onDiskFiles: []string{"foo"},
+			globErr:     true,
+			errMsg:      errGlob,
+		},
+		{
+			desc:        "no matching files",
+			onDiskFiles: []string{},
+			want:        []string{},
+		},
+		{
+			desc:        "invalid file",
+			onDiskFiles: []string{"foo"},
+			want:        []string{},
+		},
+		{
+			desc:        "one correct file",
+			onDiskFiles: []string{correctFile1},
+			want:        []string{correctFile1},
+		},
+		{
+			desc:        "two correct files",
+			onDiskFiles: []string{correctFile1, correctFile2},
+			want:        []string{correctFile1, correctFile2},
+		},
+		{
+			desc:        "two correct files with wrong files",
+			onDiskFiles: []string{"foo", correctFile1, "bar", correctFile2, "baz"},
+			want:        []string{correctFile1, correctFile2},
+		},
+	}
+	oldFilepathGlobFn := filepathGlobFn
+	for _, c := range cases {
+		filepathGlobFn = func(_ string) ([]string, error) {
+			if c.globErr {
+				return nil, fmt.Errorf(errGlob)
+			}
+			return c.onDiskFiles, nil
+		}
+
+		files, err := getBackups()
+		if c.errMsg == "" && err != nil {
+			t.Errorf("%s: unexpected error: got %v", c.desc, err)
+		} else if c.errMsg != "" {
+			if err == nil {
+				t.Errorf("%s: unexpected lack of error", c.desc)
+			}
+			if got := err.Error(); got != c.errMsg {
+				t.Errorf("%s: unexpected error msg: got\n%s\nwant\n%s", c.desc, got, c.errMsg)
+			}
+		}
+		if got := len(files); got != len(c.want) {
+			t.Errorf("%s: incorrect size of files: got %d want %d", c.desc, got, len(c.want))
+		} else {
+			for i, wantFile := range c.want {
+				if got := files[i]; got != wantFile {
+					t.Errorf("%s: incorrect file at index %d: got %s want %s", c.desc, i, got, wantFile)
+				}
+			}
+		}
+	}
+	filepathGlobFn = oldFilepathGlobFn
+}
+
+func TestFSRestorer(t *testing.T) {
+	fileContents := []byte("oneline\ntwoline\nthreeline\n")
+	tmpfile, err := ioutil.TempFile("", "timescaledb-tune-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, err = tmpfile.Write(fileContents); err != nil {
+		t.Fatal(err)
+	}
+	if err = tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	backupPath := tmpfile.Name()
+	tmpfile2, err := ioutil.TempFile("", "timescaledb-tune-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile2.Name()) // clean up
+
+	confPath := tmpfile2.Name()
+
+	r := &fsRestorer{}
+	err = r.Restore("", "")
+	if err == nil {
+		t.Fatalf("expected an error 1")
+	}
+	err = r.Restore(backupPath, "")
+	if err == nil {
+		t.Fatalf("expected an error 2")
+	}
+	err = r.Restore(backupPath, confPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	backupContents, err := ioutil.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	destContents, err := ioutil.ReadFile(tmpfile2.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := string(destContents); got != string(backupContents) {
+		t.Errorf("contents not the same: got\n%s\nwant\n%s", got, string(backupContents))
+	}
+}

--- a/pkg/tstune/checker.go
+++ b/pkg/tstune/checker.go
@@ -2,6 +2,7 @@ package tstune
 
 import (
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -63,4 +64,28 @@ func (c *skipChecker) Check(r string) (bool, error) {
 		return true, errSkip
 	}
 	return false, nil
+}
+
+type numberedListChecker struct {
+	limit    int
+	err      error
+	response int
+}
+
+func newNumberedListChecker(limit int, errMsg string, args ...interface{}) *numberedListChecker {
+	return &numberedListChecker{limit, fmt.Errorf(errMsg, args...), 0}
+}
+
+func (c *numberedListChecker) Check(r string) (bool, error) {
+	if isQuit(r) {
+		return false, c.err
+	}
+	num, err := strconv.ParseInt(r, 10, 0)
+	if err != nil {
+		return false, err
+	} else if num < 1 || int(num) > c.limit {
+		return false, nil
+	}
+	c.response = int(num)
+	return true, nil
 }

--- a/pkg/tstune/checker_test.go
+++ b/pkg/tstune/checker_test.go
@@ -1,6 +1,9 @@
 package tstune
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 type isCases struct {
 	s    string
@@ -161,4 +164,61 @@ func TestIsQuit(t *testing.T) {
 	}
 
 	testIsFunc(t, cases, isQuit)
+}
+
+func TestNewNumberedListCheckerCheck(t *testing.T) {
+	defaultErrMsg := "default error"
+	defaultLimit := 3
+	cases := []struct {
+		s      string
+		want   bool
+		errMsg string
+	}{
+		{
+			s:      "q",
+			want:   false,
+			errMsg: defaultErrMsg,
+		},
+		{
+			s:      "not a number",
+			want:   false,
+			errMsg: "strconv.ParseInt: parsing \"not a number\": invalid syntax",
+		},
+		{
+			s:    "0",
+			want: false,
+		},
+		{
+			s:    fmt.Sprintf("%d", defaultLimit+1),
+			want: false,
+		},
+		{
+			s:    "1",
+			want: true,
+		},
+		{
+			s:    "2",
+			want: true,
+		},
+		{
+			s:    fmt.Sprintf("%d", defaultLimit),
+			want: true,
+		},
+	}
+
+	for _, c := range cases {
+		checker := newNumberedListChecker(defaultLimit, defaultErrMsg)
+		got, err := checker.Check(c.s)
+		if c.errMsg == "" && err != nil {
+			t.Errorf("%s: unexpected err: got %v", c.s, err)
+		} else if c.errMsg != "" {
+			if err == nil {
+				t.Errorf("%s: unexpected lack of error", c.s)
+			} else if got := err.Error(); got != c.errMsg {
+				t.Errorf("%s: incorrect error: got %s want %s", c.s, got, c.errMsg)
+			}
+		} else if got != c.want {
+			t.Errorf("%s: incorrect value: got %v want %v", c.s, got, c.want)
+		}
+	}
 }


### PR DESCRIPTION
In the case that our tool ends up giving a configuration the user
does not like, we add a --restore flag to allow the user to replace
their conf file to a state previously backed up and stored in the
temp dir.

In testing this, we also found a bug where if the new conf file is
shorter than the current one, it will leave garbled text at the
end. This bug is fixed by first truncating the file and then
writing the new contents.