### PR TITLE
Increase default max_connections

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -31,6 +31,7 @@ var (
 func init() {
 	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
 	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
+	flag.Uint64Var(&f.MaxConns, "max-conns", 0, "Max number of connections for the database. Default is equal to our best recommendation")
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")
 	flag.StringVar(&f.PGConfig, "pg-config", "pg_config", "Path to the pg_config binary")

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 // memoryToBaseVals provides a memory from test memory levels to expected "base"
-// memory settings. These "base" values are the values if there is only 1 CPU.
-// Most settings are unaffected by number of CPUs; the exception is work_mem,
+// memory settings. These "base" values are the values if there is only 1 CPU
+// and 20 max connections to the database. Most settings are actually
+// unaffected by number of CPUs and max connections; the exception is work_mem,
 // so the adjustment is done in the init function
 var memoryToBaseVals = map[uint64]map[string]uint64{
 	10 * parse.Gigabyte: map[string]uint64{
@@ -37,21 +38,37 @@ var memoryToBaseVals = map[uint64]map[string]uint64{
 // cpuVals is the different amounts of CPUs to test
 var cpuVals = []int{1, 4, 5}
 
+// connVals is the different number of conns to test
+var connVals = []uint64{0, 19, 20, 50}
+
 // memorySettingsMatrix stores the test cases for MemoryRecommend along with
 // the expected values
-var memorySettingsMatrix = map[uint64]map[int]map[string]string{}
+var memorySettingsMatrix = map[uint64]map[int]map[uint64]map[string]string{}
 
 func init() {
 	for mem, baseMatrix := range memoryToBaseVals {
-		memorySettingsMatrix[mem] = make(map[int]map[string]string)
+		memorySettingsMatrix[mem] = make(map[int]map[uint64]map[string]string)
 		for _, cpus := range cpuVals {
-			memorySettingsMatrix[mem][cpus] = make(map[string]string)
-			cpuFactor := uint64(math.Round(float64(cpus) / 2.0))
+			memorySettingsMatrix[mem][cpus] = make(map[uint64]map[string]string)
+			for _, conns := range connVals {
+				memorySettingsMatrix[mem][cpus][conns] = make(map[string]string)
 
-			memorySettingsMatrix[mem][cpus][SharedBuffersKey] = parse.BytesToPGFormat(baseMatrix[SharedBuffersKey])
-			memorySettingsMatrix[mem][cpus][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
-			memorySettingsMatrix[mem][cpus][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
-			memorySettingsMatrix[mem][cpus][WorkMemKey] = parse.BytesToPGFormat(baseMatrix[WorkMemKey] / cpuFactor)
+				memorySettingsMatrix[mem][cpus][conns][SharedBuffersKey] = parse.BytesToPGFormat(baseMatrix[SharedBuffersKey])
+				memorySettingsMatrix[mem][cpus][conns][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
+				memorySettingsMatrix[mem][cpus][conns][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
+
+				// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
+				cpuFactor := math.Round(float64(cpus) / 2.0)
+				// Our work_mem values are derivied by a certain amount of memory lost/gained when
+				// moving away from baseConns
+				connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
+				if conns != 0 {
+					connFactor = float64(conns) / float64(baseConns)
+				}
+
+				memorySettingsMatrix[mem][cpus][conns][WorkMemKey] =
+					parse.BytesToPGFormat(uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor))
+			}
 		}
 	}
 }
@@ -60,7 +77,7 @@ func TestNewMemoryRecommender(t *testing.T) {
 	for i := 0; i < 1000000; i++ {
 		mem := rand.Uint64()
 		cpus := rand.Intn(128)
-		r := NewMemoryRecommender(mem, cpus)
+		r := NewMemoryRecommender(mem, cpus, MaxConnectionsDefault)
 		if r == nil {
 			t.Errorf("unexpected nil recommender")
 		}
@@ -82,72 +99,90 @@ func TestMemoryRecommenderRecommendWindows(t *testing.T) {
 		desc        string
 		totalMemory uint64
 		cpus        int
+		conns       uint64
 		want        string
 	}{
 		{
 			desc:        "1GB",
 			totalMemory: 1 * parse.Gigabyte,
 			cpus:        1,
+			conns:       baseConns,
 			want:        "6553" + parse.KB, // from pgtune
+		},
+		{
+			desc:        "1GB, 10 conns",
+			totalMemory: 1 * parse.Gigabyte,
+			cpus:        1,
+			conns:       10,
+			want:        "13107" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "1GB, 4 cpus",
 			totalMemory: 1 * parse.Gigabyte,
 			cpus:        4,
+			conns:       baseConns,
 			want:        "3276" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "2GB",
 			totalMemory: 2 * parse.Gigabyte,
 			cpus:        1,
+			conns:       baseConns,
 			want:        "13107" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "2GB, 5 cpus",
 			totalMemory: 2 * parse.Gigabyte,
 			cpus:        5,
+			conns:       baseConns,
 			want:        "4369" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "3GB",
 			totalMemory: 3 * parse.Gigabyte,
 			cpus:        1,
+			conns:       baseConns,
 			want:        "21845" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "3GB, 3 cpus",
 			totalMemory: 3 * parse.Gigabyte,
 			cpus:        3,
+			conns:       baseConns,
 			want:        "10922" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "8GB",
 			totalMemory: 8 * parse.Gigabyte,
 			cpus:        1,
+			conns:       baseConns,
 			want:        "64" + parse.MB, // from pgtune
 		},
 		{
 			desc:        "8GB, 8 cpus",
 			totalMemory: 8 * parse.Gigabyte,
 			cpus:        8,
+			conns:       baseConns,
 			want:        "16" + parse.MB, // from pgtune
 		},
 		{
 			desc:        "16GB",
 			totalMemory: 16 * parse.Gigabyte,
 			cpus:        1,
+			conns:       baseConns,
 			want:        "135441" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "16GB, 10 cpus",
 			totalMemory: 16 * parse.Gigabyte,
 			cpus:        10,
+			conns:       baseConns,
 			want:        "27088" + parse.KB, // from pgtune
 		},
 	}
 
 	for _, c := range cases {
-		mr := &MemoryRecommender{c.totalMemory, c.cpus}
+		mr := NewMemoryRecommender(c.totalMemory, c.cpus, c.conns)
 		if got := mr.recommendWindows(); got != c.want {
 			t.Errorf("%s: incorrect value: got %s want %s", c.desc, got, c.want)
 		}
@@ -155,17 +190,19 @@ func TestMemoryRecommenderRecommendWindows(t *testing.T) {
 }
 
 func TestMemoryRecommenderRecommend(t *testing.T) {
-	for totalMemory, outerMatrix := range memorySettingsMatrix {
-		for cpus, cases := range outerMatrix {
-			mr := &MemoryRecommender{totalMemory, cpus}
-			testRecommender(t, mr, cases)
+	for totalMemory, cpuMatrix := range memorySettingsMatrix {
+		for cpus, connMatrix := range cpuMatrix {
+			for conns, cases := range connMatrix {
+				mr := NewMemoryRecommender(totalMemory, cpus, conns)
+				testRecommender(t, mr, cases)
+			}
 		}
 	}
 }
 
 func TestMemoryRecommenderRecommendPanic(t *testing.T) {
 	func() {
-		r := &MemoryRecommender{1, 1}
+		r := NewMemoryRecommender(1, 1, 1)
 		defer func() {
 			if re := recover(); re == nil {
 				t.Errorf("did not panic when should")
@@ -176,11 +213,17 @@ func TestMemoryRecommenderRecommendPanic(t *testing.T) {
 }
 
 func TestMemorySettingsGroup(t *testing.T) {
-	for totalMemory, outerMatrix := range memorySettingsMatrix {
-		for cpus, matrix := range outerMatrix {
-			config := NewSystemConfig(totalMemory, cpus, "10")
-			sg := GetSettingsGroup(MemoryLabel, config)
-			testSettingGroup(t, sg, matrix, MemoryLabel, MemoryKeys)
+	for totalMemory, cpuMatrix := range memorySettingsMatrix {
+		for cpus, connMatrix := range cpuMatrix {
+			for conns, matrix := range connMatrix {
+				config := getDefaultTestSystemConfig(t)
+				config.CPUs = cpus
+				config.Memory = totalMemory
+				config.maxConns = conns
+
+				sg := GetSettingsGroup(MemoryLabel, config)
+				testSettingGroup(t, sg, matrix, MemoryLabel, MemoryKeys)
+			}
 		}
 	}
 }

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -88,7 +88,9 @@ func TestParallelRecommenderRecommendPanics(t *testing.T) {
 
 func TestParallelSettingsGroup(t *testing.T) {
 	for cpus, matrix := range parallelSettingsMatrix {
-		config := NewSystemConfig(1024, cpus, "9.6")
+		config := getDefaultTestSystemConfig(t)
+		config.CPUs = cpus
+		config.PGMajorVersion = "9.6" // 9.6 lacks one key
 		sg := GetSettingsGroup(ParallelLabel, config)
 		testSettingGroup(t, sg, matrix, ParallelLabel, ParallelKeys)
 

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -68,7 +68,8 @@ func TestWALRecommenderRecommendPanic(t *testing.T) {
 
 func TestWALSettingsGroup(t *testing.T) {
 	for totalMemory, matrix := range walSettingsMatrix {
-		config := NewSystemConfig(totalMemory, 4, "10")
+		config := getDefaultTestSystemConfig(t)
+		config.Memory = totalMemory
 		sg := GetSettingsGroup(WALLabel, config)
 		testSettingGroup(t, sg, matrix, WALLabel, WALKeys)
 	}

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version is the version of this library
-	Version = "0.3.0"
+	Version = "0.4.0-dev"
 
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"
@@ -98,6 +98,7 @@ type TunerFlags struct {
 	Memory    string // amount of memory to base recommendations on
 	NumCPUs   uint   // number of CPUs to base recommendations on
 	PGConfig  string // path to pg_config binary
+	MaxConns  uint64 // max number of database connections
 	ConfPath  string // path to the postgresql.conf file
 	DestPath  string // path to output file
 	YesAlways bool   // always respond yes to prompts
@@ -161,7 +162,7 @@ func (t *Tuner) initializeSystemConfig() (*pgtune.SystemConfig, error) {
 		cpus = runtime.NumCPU()
 	}
 
-	return pgtune.NewSystemConfig(totalMemory, cpus, pgVersion), nil
+	return pgtune.NewSystemConfig(totalMemory, cpus, pgVersion, t.flags.MaxConns)
 }
 
 func (t *Tuner) restore(r restorer, filePath string) error {


### PR DESCRIPTION
The old default max_connections of 20 was a bit low for some use
cases. Increasing the max_connections to 50 should be more reasonable.
In addition, we add the scaffolding to allow a user to override the
given max_connections recommendation with their own value based on
their usage pattern. Since we are doing this, we need to handle
adjusting the work_mem based on max_connections since with more
connections you will want to reduce the work_mem for each.