### PR TITLE
Remove indirection var printFn from tstune

### DIFF
--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -309,21 +309,6 @@ func TestGetConfigFileStateErr(t *testing.T) {
 	}
 }
 
-var errDefault = fmt.Errorf("erroring")
-
-type testWriter struct {
-	shouldErr bool
-	lines     []string
-}
-
-func (w *testWriter) Write(buf []byte) (int, error) {
-	if w.shouldErr {
-		return 0, errDefault
-	}
-	w.lines = append(w.lines, string(buf))
-	return 0, nil
-}
-
 func TestConfigFileStateWriteTo(t *testing.T) {
 	cases := []struct {
 		desc      string
@@ -360,7 +345,7 @@ func TestConfigFileStateWriteTo(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", c.desc, err)
 		} else if err == nil && c.shouldErr {
 			t.Errorf("%s: unexpected lack of error", c.desc)
-		} else if c.shouldErr && err != errDefault {
+		} else if c.shouldErr && err.Error() != errTestWriter {
 			t.Errorf("%s: unexpected type of error: %v", c.desc, err)
 		}
 

--- a/pkg/tstune/io_handler_test.go
+++ b/pkg/tstune/io_handler_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+const errTestWriter = "erroring"
+
+type testWriter struct {
+	shouldErr bool
+	lines     []string
+}
+
+func (w *testWriter) Write(buf []byte) (int, error) {
+	if w.shouldErr {
+		return 0, fmt.Errorf(errTestWriter)
+	}
+	w.lines = append(w.lines, string(buf))
+	return 0, nil
+}
+
 func TestIOHandlerExit(t *testing.T) {
 	p := &testPrinter{}
 

--- a/pkg/tstune/print.go
+++ b/pkg/tstune/print.go
@@ -19,8 +19,6 @@ var (
 	promptColor    = color.New(color.FgMagenta, color.Bold) // color for prompt/questions requiring user input
 	successColor   = color.New(color.FgGreen, color.Bold)
 	errorColor     = color.New(color.FgRed, color.Bold)
-
-	printFn = fmt.Fprintf
 )
 
 type printer interface {
@@ -49,12 +47,12 @@ func (p *colorPrinter) Prompt(format string, args ...interface{}) {
 
 func (p *colorPrinter) Success(format string, args ...interface{}) {
 	p.printWithColor(successColor, successLabel)
-	printFn(p.w, format+"\n", args...)
+	fmt.Fprintf(p.w, format+"\n", args...)
 }
 
 func (p *colorPrinter) Error(label string, format string, args ...interface{}) {
 	p.printWithColor(errorColor, label+": ")
-	printFn(p.w, format+"\n", args...)
+	fmt.Fprintf(p.w, format+"\n", args...)
 }
 
 type noColorPrinter struct {
@@ -62,17 +60,17 @@ type noColorPrinter struct {
 }
 
 func (p *noColorPrinter) Statement(format string, args ...interface{}) {
-	printFn(p.w, noColorPrefixStatement+format+"\n", args...)
+	fmt.Fprintf(p.w, noColorPrefixStatement+format+"\n", args...)
 }
 
 func (p *noColorPrinter) Prompt(format string, args ...interface{}) {
-	printFn(p.w, noColorPrefixPrompt+format, args...)
+	fmt.Fprintf(p.w, noColorPrefixPrompt+format, args...)
 }
 
 func (p *noColorPrinter) Success(format string, args ...interface{}) {
-	printFn(p.w, strings.ToUpper(successLabel)+format+"\n", args...)
+	fmt.Fprintf(p.w, strings.ToUpper(successLabel)+format+"\n", args...)
 }
 
 func (p *noColorPrinter) Error(label string, format string, args ...interface{}) {
-	printFn(p.w, strings.ToUpper(label)+": "+format+"\n", args...)
+	fmt.Fprintf(p.w, strings.ToUpper(label)+": "+format+"\n", args...)
 }


### PR DESCRIPTION
Using fmt.Fprintf is nicer and does not involve as much setup code
for each test to redefine the printFn each time. This is also
changes any hardcoded os.Stdout/os.Stderr to the correct values
inside tstune.ioHandler.