### PR TITLE
Refactor to deal with truncation in config writing

### DIFF
--- a/pkg/tstune/backup.go
+++ b/pkg/tstune/backup.go
@@ -81,16 +81,6 @@ func (r *fsRestorer) Restore(backupPath, confPath string) error {
 	}
 	defer confFile.Close()
 
-	// in case new file is shorter than old, need to truncate first
-	err = confFile.Truncate(0)
-	if err != nil {
-		return err
-	}
-	_, err = confFile.Seek(0, 0)
-	if err != nil {
-		return err
-	}
-
 	_, err = backupCFS.WriteTo(confFile)
 	if err != nil {
 		return err

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -310,16 +310,6 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 		}
 		defer f.Close()
 
-		// in case new file is shorter than old, need to truncate first
-		err = f.Truncate(0)
-		if err != nil {
-			t.handler.exit(1, "could not open %s for writing: %v", outPath, err)
-		}
-		_, err = f.Seek(0, 0)
-		if err != nil {
-			t.handler.exit(1, "could not open %s for writing: %v", outPath, err)
-		}
-
 		_, err = t.cfs.WriteTo(f)
 		ifErrHandle(err)
 	} else {


### PR DESCRIPTION
By defining a new interface that handles seeks and truncating, we
can move that logic into tstune.configFileState.WriteTo. This
removes redundant code and improves testability since we can now
create a test interface that also seeks and truncates for testing
those code paths.