### PR TITLE
Refactor conf write function into own function

### DIFF
--- a/pkg/tstune/backup.go
+++ b/pkg/tstune/backup.go
@@ -19,7 +19,7 @@ const (
 
 // allows us to substitute mock versions in tests
 var filepathGlobFn = filepath.Glob
-var osCreateFn = func(path string) (io.Writer, error) {
+var osCreateFn = func(path string) (io.WriteCloser, error) {
 	return os.Create(path)
 }
 

--- a/pkg/tstune/io_handler_test.go
+++ b/pkg/tstune/io_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-const errTestWriter = "erroring"
+const errTestWriter = "error on write"
 
 type testWriter struct {
 	shouldErr bool


### PR DESCRIPTION
This change (1) reduces the complexity of the Run function and
(2) makes more parts of the CLI testable. Now we are able to test
that the writing portion is actually correct and handles errors
appropriately.