### PR TITLE
Add ability to override the machine's PG version

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/timescale/timescaledb-tune/pkg/tstune"
 )
@@ -31,6 +32,7 @@ var (
 func init() {
 	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
 	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
+	flag.StringVar(&f.PGVersion, "pg-version", "", "Major version of PostgreSQL to base recommendations on. Default is determined via pg_config. Valid values: "+strings.Join(tstune.ValidPGVersions, ", "))
 	flag.Uint64Var(&f.MaxConns, "max-conns", 0, "Max number of connections for the database. Default is equal to our best recommendation")
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")


### PR DESCRIPTION
Like memory and CPU, users may want to specify their version of
PostgreSQL to use for recommendations. For example, when generating
configuration files for another machine that the tool is being
run on. This also obviates the need for pg_config to be installed
on the machine where the tool is being run since it can just be
provided.