### PR TITLE
Fix work_mem recommendation to not be too low

### DIFF
--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -76,8 +75,6 @@ var (
 	// allows us to substitute mock versions in tests
 	getPGConfigVersionFn = getPGConfigVersion
 	filepathAbsFn        = filepath.Abs
-
-	pgVersionRegex = regexp.MustCompile("^PostgreSQL ([0-9]+?).([0-9]+?).*")
 
 	// ValidPGVersions is a slice representing the major versions of PostgreSQL
 	// for which recommendations can be generated.


### PR DESCRIPTION
Given the inputs, the work_mem formulas could potentially return
values below 64KB, which is invalid and blocks PostgreSQL from
starting. These changes ensure that work_mem is always at least
64KB.

Fixes #38 