### PR TITLE
Improve recording of timescaledb-tune parameters

### DIFF
--- a/pkg/tstune/backup_test.go
+++ b/pkg/tstune/backup_test.go
@@ -30,7 +30,11 @@ func TestBackup(t *testing.T) {
 	oldOSCreateFn := osCreateFn
 	now := time.Now()
 	lines := []string{"foo", "bar", "baz", "quaz"}
-	cfs := &configFileState{lines: lines}
+	r := stringSliceToBytesReader(lines)
+	cfs, err := getConfigFileState(r)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	wantFileName := backupFilePrefix + now.Format(backupDateFmt)
 	wantPath := path.Join(os.TempDir(), wantFileName)
 

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/timescale/timescaledb-tune/pkg/pgtune"
 )
 
+func stringSliceToBytesReader(lines []string) *bytes.Buffer {
+	return bytes.NewBufferString(strings.Join(lines, "\n"))
+}
+
 func TestFileExists(t *testing.T) {
 	existsName := "exists.txt"
 	errorName := "error.txt"
@@ -54,6 +58,70 @@ func TestFileExists(t *testing.T) {
 	}
 
 	osStatFn = oldOSStatFn
+}
+
+func TestRemoveDuplicatesProcessor(t *testing.T) {
+	lines := []*configLine{
+		{content: "foo = 'bar'"},
+		{content: "foo = 'baz'"},
+		{content: "foo = 'quaz'"},
+	}
+	p := &removeDuplicatesProcessor{regex: keyToRegexQuoted("foo")}
+	p.Process(lines[0])
+	if lines[0].remove {
+		t.Errorf("first instance incorrectly marked for remove")
+	}
+
+	check := func(idx int) {
+		err := p.Process(lines[idx])
+		if err != nil {
+			t.Errorf("unexpected error on test %d: %v", idx, err)
+		}
+		if !lines[idx-1].remove {
+			t.Errorf("configLine not marked to remove on test %d", idx)
+		}
+		if lines[idx].remove {
+			t.Errorf("configLine incorrectly marked to remove on test %d", idx)
+		}
+	}
+
+	check(1)
+	check(2)
+}
+
+func TestGetRemoveDuplicatesProcessors(t *testing.T) {
+	cases := []struct {
+		desc string
+		keys []string
+	}{
+		{
+			desc: "no keys",
+			keys: []string{},
+		},
+		{
+			desc: "one key",
+			keys: []string{"foo"},
+		},
+		{
+			desc: "two keys",
+			keys: []string{"foo", "bar"},
+		},
+	}
+
+	for _, c := range cases {
+		procs := getRemoveDupeProcessors(c.keys)
+		if got := len(procs); got != len(c.keys) {
+			t.Errorf("%s: incorrect length: got %d want %d", c.desc, got, len(c.keys))
+		} else {
+			for i, key := range c.keys {
+				rdp := procs[i].(*removeDuplicatesProcessor)
+				want := keyToRegexQuoted(key).String()
+				if got := rdp.regex.String(); got != want {
+					t.Errorf("%s: incorrect proc at %d: got %s want %s", c.desc, i, got, want)
+				}
+			}
+		}
+	}
 }
 
 func TestGetConfigFilePath(t *testing.T) {
@@ -186,7 +254,7 @@ func TestGetConfigFileState(t *testing.T) {
 			desc:  "empty file",
 			lines: []string{},
 			want: &configFileState{
-				lines:            []string{},
+				lines:            []*configLine{},
 				tuneParseResults: make(map[string]*tunableParseResult),
 				sharedLibResult:  nil,
 			},
@@ -195,7 +263,7 @@ func TestGetConfigFileState(t *testing.T) {
 			desc:  "single irrelevant line",
 			lines: []string{"foo"},
 			want: &configFileState{
-				lines:            []string{"foo"},
+				lines:            []*configLine{{content: "foo"}},
 				tuneParseResults: make(map[string]*tunableParseResult),
 				sharedLibResult:  nil,
 			},
@@ -204,7 +272,7 @@ func TestGetConfigFileState(t *testing.T) {
 			desc:  "shared lib line only",
 			lines: []string{sharedLibLine},
 			want: &configFileState{
-				lines:            []string{sharedLibLine},
+				lines:            []*configLine{{content: sharedLibLine}},
 				tuneParseResults: make(map[string]*tunableParseResult),
 				sharedLibResult: &sharedLibResult{
 					idx:          0,
@@ -219,7 +287,14 @@ func TestGetConfigFileState(t *testing.T) {
 			desc:  "multi-line",
 			lines: []string{"foo", sharedLibLine, "bar", memoryLine, walLine, "baz"},
 			want: &configFileState{
-				lines: []string{"foo", sharedLibLine, "bar", memoryLine, walLine, "baz"},
+				lines: []*configLine{
+					{content: "foo"},
+					{content: sharedLibLine},
+					{content: "bar"},
+					{content: memoryLine},
+					{content: walLine},
+					{content: "baz"},
+				},
 				tuneParseResults: map[string]*tunableParseResult{
 					pgtune.SharedBuffersKey: {
 						idx:       3,
@@ -254,8 +329,8 @@ func TestGetConfigFileState(t *testing.T) {
 			t.Errorf("%s: incorrect number of cfs lines: got %d want %d", c.desc, got, len(c.want.lines))
 		} else {
 			for i, got := range cfs.lines {
-				if want := c.want.lines[i]; got != want {
-					t.Errorf("%s: incorrect line at %d: got\n%s\nwant\n%s", c.desc, i, got, want)
+				if want := c.want.lines[i].content; got.content != want {
+					t.Errorf("%s: incorrect line at %d: got\n%s\nwant\n%s", c.desc, i, got.content, want)
 				}
 			}
 		}
@@ -310,6 +385,55 @@ func TestGetConfigFileStateErr(t *testing.T) {
 	}
 }
 
+const errProcess = "process error"
+
+type countProcessor struct {
+	count     int
+	shouldErr bool
+}
+
+func (p *countProcessor) Process(_ *configLine) error {
+	if p.shouldErr {
+		return fmt.Errorf(errProcess)
+	}
+	p.count++
+	return nil
+}
+
+func TestConfigFileStateProcessLines(t *testing.T) {
+	countProc1 := &countProcessor{}
+	countProc2 := &countProcessor{}
+	procs := []configLineProcessor{countProc1, countProc2}
+	lines := []string{"foo", "bar", "baz"}
+	wantCount := len(lines)
+	r := stringSliceToBytesReader(lines)
+	cfs, err := getConfigFileState(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = cfs.ProcessLines(procs...)
+	if err != nil {
+		t.Errorf("unexpected error in processing: %v", err)
+	}
+	if got := countProc1.count; got != wantCount {
+		t.Errorf("incorrect count for countProc1: got %d want %d", got, wantCount)
+	}
+	if got := countProc2.count; got != wantCount {
+		t.Errorf("incorrect count for countProc2: got %d want %d", got, wantCount)
+	}
+
+	badCountProc := &countProcessor{shouldErr: true}
+	procs = append(procs, badCountProc)
+	err = cfs.ProcessLines(procs...)
+	if err == nil {
+		t.Errorf("unexpected lack of error")
+	}
+	if got := err.Error(); got != errProcess {
+		t.Errorf("unexpected error: got %s want %s", got, errProcess)
+	}
+}
+
 const (
 	errTestTruncate = "truncate error"
 	errTestSeek     = "seek error"
@@ -337,60 +461,84 @@ func (w *testTruncateWriter) Truncate(_ int64) error {
 
 func TestConfigFileStateWriteTo(t *testing.T) {
 	cases := []struct {
-		desc   string
-		lines  []string
-		errMsg string
-		w      io.Writer
+		desc      string
+		lines     []string
+		removeIdx int
+		errMsg    string
+		w         io.Writer
 	}{
 		{
-			desc:  "empty",
-			lines: []string{},
-			w:     &testWriter{false, []string{}},
+			desc:      "empty",
+			lines:     []string{},
+			removeIdx: -1,
+			w:         &testWriter{false, []string{}},
 		},
 		{
-			desc:  "one line",
-			lines: []string{"foo"},
-			w:     &testWriter{false, []string{}},
+			desc:      "one line",
+			lines:     []string{"foo"},
+			removeIdx: -1,
+			w:         &testWriter{false, []string{}},
 		},
 		{
-			desc:  "many lines",
-			lines: []string{"foo", "bar", "baz", "quaz"},
-			w:     &testWriter{false, []string{}},
+			desc:      "many lines",
+			lines:     []string{"foo", "bar", "baz", "quaz"},
+			removeIdx: -1,
+			w:         &testWriter{false, []string{}},
 		},
 		{
-			desc:  "many lines w/ truncating",
-			lines: []string{"foo", "bar", "baz", "quaz"},
-			w:     &testTruncateWriter{&testWriter{false, []string{}}, false, false},
+			desc:      "many lines w/ truncating",
+			lines:     []string{"foo", "bar", "baz", "quaz"},
+			removeIdx: -1,
+			w:         &testTruncateWriter{&testWriter{false, []string{}}, false, false},
 		},
 		{
-			desc:   "error in truncate",
-			lines:  []string{"foo"},
-			errMsg: errTestTruncate,
-			w:      &testTruncateWriter{&testWriter{true, []string{}}, false, true},
+			desc:      "many lines, remove middle line",
+			lines:     []string{"foo", "bar", "baz"},
+			removeIdx: 1,
+			w:         &testWriter{false, []string{}},
 		},
 		{
-			desc:   "error in seek",
-			lines:  []string{"foo"},
-			errMsg: errTestSeek,
-			w:      &testTruncateWriter{&testWriter{true, []string{}}, true, false},
+			desc:      "error in truncate",
+			lines:     []string{"foo"},
+			removeIdx: -1,
+			errMsg:    errTestTruncate,
+			w:         &testTruncateWriter{&testWriter{true, []string{}}, false, true},
 		},
 		{
-			desc:   "error in write w/o truncating",
-			lines:  []string{"foo"},
-			errMsg: errTestWriter,
-			w:      &testWriter{true, []string{}},
+			desc:      "error in seek",
+			lines:     []string{"foo"},
+			removeIdx: -1,
+			errMsg:    errTestSeek,
+			w:         &testTruncateWriter{&testWriter{true, []string{}}, true, false},
 		},
 		{
-			desc:   "error in write w/ truncating",
-			lines:  []string{"foo"},
-			errMsg: errTestWriter,
-			w:      &testTruncateWriter{&testWriter{true, []string{}}, false, false},
+			desc:      "error in write w/o truncating",
+			lines:     []string{"foo"},
+			removeIdx: -1,
+			errMsg:    errTestWriter,
+			w:         &testWriter{true, []string{}},
+		},
+		{
+			desc:      "error in write w/ truncating",
+			lines:     []string{"foo"},
+			removeIdx: -1,
+			errMsg:    errTestWriter,
+			w:         &testTruncateWriter{&testWriter{true, []string{}}, false, false},
 		},
 	}
 
 	for _, c := range cases {
-		cfs := &configFileState{lines: c.lines}
-		_, err := cfs.WriteTo(c.w)
+		r := stringSliceToBytesReader(c.lines)
+		cfs, err := getConfigFileState(r)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", c.desc, err)
+		}
+
+		if c.removeIdx >= 0 {
+			cfs.lines[c.removeIdx].remove = true
+		}
+
+		_, err = cfs.WriteTo(c.w)
 		if c.errMsg == "" && err != nil {
 			t.Errorf("%s: unexpected error: %v", c.desc, err)
 		} else if c.errMsg != "" {
@@ -409,12 +557,22 @@ func TestConfigFileStateWriteTo(t *testing.T) {
 			w = temp.testWriter
 		}
 
+		lineCntModifier := 0
+		if c.removeIdx >= 0 {
+			lineCntModifier = 1
+		}
+
 		if len(c.lines) > 0 && c.errMsg == "" {
-			if got := len(w.lines); got != len(c.lines) {
-				t.Errorf("%s: incorrect output len: got %d want %d", c.desc, got, len(c.lines))
+			if got := len(w.lines); got != len(c.lines)-lineCntModifier {
+				t.Errorf("%s: incorrect output len: got %d want %d", c.desc, got, len(c.lines)-lineCntModifier)
 			}
+			idxModifier := 0
 			for i, want := range c.lines {
-				if got := w.lines[i]; got != want+"\n" {
+				if i == c.removeIdx {
+					idxModifier = 1
+					continue
+				}
+				if got := w.lines[i-idxModifier]; got != want+"\n" {
 					t.Errorf("%s: incorrect line at %d: got %s want %s", c.desc, i, got, want+"\n")
 				}
 			}


### PR DESCRIPTION
Previously tstune.Tuner would always write new lines for parameters
it generated, such as timescaledb.last_tuned_version. This created a
messy end to conf files when tuned multiple times.

This PR updates Tuner to search for its parameters first, and update
them in place if they exist. If not, then it appends them to the end
of the file. Additionally, support is added for removing duplicate
lines (and potentially other transformations, e.g., commenting out
unused lines instead). For now this will clean up the mess we may
have created before with multiple lines for timescaledb.last_tuned
and timescaledb.last_tuned_version. In the future we can leverage
this to warn users about parameters being overridden later in the
file, comment out unused duplicates, and other 'linting' changes.

This also improves the correctness of the regexes we generate for
parameters but properly escaping meta characters.