### PR TITLE
Refactor tstune tests

### DIFF
--- a/pkg/tstune/config_file.go
+++ b/pkg/tstune/config_file.go
@@ -122,10 +122,10 @@ func (p *removeDuplicatesProcessor) Process(l *configLine) error {
 	return nil
 }
 
-// getRemoveDupeProcessors is a convenience function for creating a slice
+// getRemoveDuplicatesProcessors is a convenience function for creating a slice
 // of configLineProcessors (of the removeDuplicatesProcessor type) for a set of
 // keys.
-func getRemoveDupeProcessors(keys []string) []configLineProcessor {
+func getRemoveDuplicatesProcessors(keys []string) []configLineProcessor {
 	ret := []configLineProcessor{}
 	for _, key := range keys {
 		ret = append(ret, &removeDuplicatesProcessor{regex: keyToRegexQuoted(key)})

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -109,7 +109,7 @@ func TestGetRemoveDuplicatesProcessors(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		procs := getRemoveDupeProcessors(c.keys)
+		procs := getRemoveDuplicatesProcessors(c.keys)
 		if got := len(procs); got != len(c.keys) {
 			t.Errorf("%s: incorrect length: got %d want %d", c.desc, got, len(c.keys))
 		} else {

--- a/pkg/tstune/tune_settings.go
+++ b/pkg/tstune/tune_settings.go
@@ -17,7 +17,7 @@ const (
 	lastTunedVersionParam = "timescaledb.last_tuned_version"
 )
 
-// ourParams is a list of paramters that the tuning program adds to the conf file
+// ourParams is a list of parameters that the tuning program adds to the conf file
 var ourParams = []string{lastTunedParam, lastTunedVersionParam}
 
 // ourParamToValue returns the configuration file line for a given

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -311,7 +311,7 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 	// Add our params to the conf file, and cleanup because old versions of Tuner
 	// were noisy and left these params each time.
 	t.processOurParams()
-	t.cfs.ProcessLines(getRemoveDupeProcessors(ourParams)...)
+	t.cfs.ProcessLines(getRemoveDuplicatesProcessors(ourParams)...)
 
 	// Wrap up: Either write it out, or show success in --dry-run
 	if !t.flags.DryRun {
@@ -586,7 +586,7 @@ func (t *Tuner) processOurParams() {
 
 	// Since we usually append our settings to the end, it is more efficient
 	// to work backwards. The basic idea is to check each line against our
-	// map of regexes and if it matches we've found the latest occurence of
+	// map of regexes and if it matches we've found the latest occurrence of
 	// that parameter, so we can 1) skip testing other regexes and 2) move
 	// the parameter from findRegexes map to foundLines. Once each has been
 	// found, we can quit searching (or go until the end).


### PR DESCRIPTION
This PR refactors some of the duplicated setup for tests in
tuner_test.go into a shared function. Additionally it merges the
two tests that tested Tuner.processTunables() into one test for
further cleanup.