### PR TITLE
Add test for panic condition of regex parsing

### DIFF
--- a/pkg/tstune/tune_settings.go
+++ b/pkg/tstune/tune_settings.go
@@ -103,9 +103,12 @@ func keyToRegexQuoted(key string) *regexp.Regexp {
 }
 
 // parseWithRegex takes a line and attempts to parse it using a given regular
-// expression regex. If succesfful, a tunableParseResult is returned based on
-// the contents of the line; otherwise, nil. Panics if the regex parsing returns
-// and unexpected result.
+// expression regex. The regex is expected to produce 5 capture groups:
+// 1) the full result, 2) whether the line is preceded by # or not, 3) the
+// parameter name/key, 4) the parameter value, and 5) any comments at the end.
+// If successful, a tunableParseResult is returned based on the contents of the
+// line; otherwise, nil. Panics if the regex parsing returns and unexpected
+// result (i.e., too many capture groups).
 func parseWithRegex(line string, regex *regexp.Regexp) *tunableParseResult {
 	res := regex.FindStringSubmatch(line)
 	if len(res) > 0 {

--- a/pkg/tstune/tune_settings_test.go
+++ b/pkg/tstune/tune_settings_test.go
@@ -2,6 +2,7 @@ package tstune
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -253,4 +254,18 @@ func TestParseWithRegex(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestParseWithRegexPanic(t *testing.T) {
+	// Don't use regexp.QuoteMeta so that we can sneak meta chars into and cause
+	// an extra capture group, (bar)+
+	badRegex := regexp.MustCompile(fmt.Sprintf(tuneRegexFmt, "foo(bar)+"))
+	line := "#foobar = 5 #commented"
+
+	defer func() {
+		if re := recover(); re == nil {
+			t.Errorf("did not panic when should")
+		}
+	}()
+	parseWithRegex(line, badRegex)
 }

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -245,13 +245,12 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 	}
 
 	// Generate current conf file state
-	cfs, err := getConfigFileState(file)
+	t.cfs, err = getConfigFileState(file)
 	ifErrHandle(err)
-	t.cfs = cfs
 
 	// Write backup
 	if !t.flags.DryRun {
-		backupPath, err := backup(cfs)
+		backupPath, err := backup(t.cfs)
 		t.handler.p.Statement("Writing backup to:")
 		fmt.Fprintf(t.handler.outErr, backupPath+"\n\n")
 		ifErrHandle(err)


### PR DESCRIPTION
By supplying a regex that has not been properly quoted, we can
test the panic scenario of tstune.parseWithRegex. In addition, we
update the godoc to elaborate on what is expected of the function.