### PR TITLE
Add file path to psql.conf in alpine linux

### DIFF
--- a/pkg/tstune/config_file.go
+++ b/pkg/tstune/config_file.go
@@ -17,6 +17,7 @@ const (
 	fileNameDebianFmt = "/etc/postgresql/%s/main/postgresql.conf"
 	fileNameRPMFmt    = "/var/lib/pgsql/%s/data/postgresql.conf"
 	fileNameArch      = "/var/lib/postgres/data/postgresql.conf"
+	fileNameAlpine    = "/var/lib/postgresql/data/postgresql.conf"
 
 	errConfigNotFoundFmt = "could not find postgresql.conf at any of these locations:\n%v"
 )
@@ -68,8 +69,11 @@ func getConfigFilePath(os, pgVersion string) (string, error) {
 		if fileName != "" {
 			return fileName, nil
 		}
-
 		fileName = try(fileNameArch)
+		if fileName != "" {
+			return fileName, nil
+		}
+		fileName = try(fileNameAlpine)
 		if fileName != "" {
 			return fileName, nil
 		}

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -204,6 +204,13 @@ func TestGetConfigFilePath(t *testing.T) {
 			wantFile:  fileNameArch,
 			shouldErr: false,
 		},
+		{
+			desc:      "linux - alpine",
+			os:        osLinux,
+			files:     []string{fileNameAlpine},
+			wantFile:  fileNameAlpine,
+			shouldErr: false,
+		},
 
 		{
 			desc:      "linux - no",


### PR DESCRIPTION
Currently timescale-tune do not load postgres.conf in Alpine linux.

Example:
```
docker run -d --name some-timescaledb -p 5432:5432 timescale/timescaledb
docker exec -it some-timescaledb bash
timescaledb-tune 
exit: could not find postgresql.conf at any of these locations:
/etc/postgresql/9.6/main/postgresql.conf
/var/lib/pgsql/9.6/data/postgresql.conf
/var/lib/postgres/data/postgresql.conf
```

This PR adds support to Docker/Alpine linux distribuiton. 