### PR TITLE
Update panic message to include bad value

### DIFF
--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -40,7 +40,7 @@ var (
 
 func parseIntToFloatUnits(bytes uint64) (float64, string) {
 	if bytes <= 0 {
-		panic("bytes must be at least 1 byte")
+		panic(fmt.Sprintf("bytes must be at least 1 byte (got %d)", bytes))
 	}
 	divisor := 1.0
 	units := B


### PR DESCRIPTION
Debugging what caused the internal/parse library to panic when
given an invalid bytes number is more difficult if that invalid
value is not printed in the error.