### PR TITLE
Allow parent dirs to be specified instead of path

### DIFF
--- a/pkg/tstune/config_file.go
+++ b/pkg/tstune/config_file.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 )
@@ -21,19 +20,6 @@ const (
 
 	errConfigNotFoundFmt = "could not find postgresql.conf at any of these locations:\n%v"
 )
-
-// allows us to substitute mock versions in tests
-var osStatFn = os.Stat
-
-// fileExists is a simple check for stating if a file exists and if any error
-// occurs it returns false.
-func fileExists(name string) bool {
-	// for our purposes, any error is a problem, so assume it does not exist
-	if _, err := osStatFn(name); err != nil {
-		return false
-	}
-	return true
-}
 
 type truncateWriter interface {
 	io.Writer

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -16,51 +16,6 @@ func stringSliceToBytesReader(lines []string) *bytes.Buffer {
 	return bytes.NewBufferString(strings.Join(lines, "\n"))
 }
 
-func TestFileExists(t *testing.T) {
-	existsName := "exists.txt"
-	errorName := "error.txt"
-	cases := []struct {
-		desc     string
-		filename string
-		want     bool
-	}{
-		{
-			desc:     "found file",
-			filename: existsName,
-			want:     true,
-		},
-		{
-			desc:     "not found file",
-			filename: "ghost.txt",
-			want:     false,
-		},
-		{
-			desc:     "error in stat",
-			filename: errorName,
-			want:     false,
-		},
-	}
-
-	oldOSStatFn := osStatFn
-	osStatFn = func(name string) (os.FileInfo, error) {
-		if name == existsName {
-			return nil, nil
-		} else if name == errorName {
-			return nil, fmt.Errorf("this is an error")
-		} else {
-			return nil, os.ErrNotExist
-		}
-	}
-
-	for _, c := range cases {
-		if got := fileExists(c.filename); got != c.want {
-			t.Errorf("%s: incorrect result: got %v want %v", c.desc, got, c.want)
-		}
-	}
-
-	osStatFn = oldOSStatFn
-}
-
 func TestRemoveDuplicatesProcessor(t *testing.T) {
 	lines := []*configLine{
 		{content: "foo = 'bar'"},

--- a/pkg/tstune/utils.go
+++ b/pkg/tstune/utils.go
@@ -3,6 +3,8 @@ package tstune
 import (
 	"fmt"
 	"math"
+	"path/filepath"
+	"os"
 
 	"github.com/timescale/timescaledb-tune/pkg/pgutils"
 )
@@ -17,6 +19,38 @@ var ValidPGVersions = []string{
 
 // allows us to substitute mock versions in tests
 var getPGConfigVersionFn = pgutils.GetPGConfigVersionAtPath
+
+// allows us to substitute mock versions in tests
+var osStatFn = os.Stat
+
+// fileExists is a simple check for stating if a file exists and if any error
+// occurs it returns false.
+func fileExists(name string) bool {
+	// for our purposes, any error is a problem, so assume it does not exist
+	if _, err := osStatFn(name); err != nil {
+		return false
+	}
+	return true
+}
+
+func pathIsDir(name string) bool {
+	fi, err := osStatFn(name);
+	// for our purposes, any error is a problem, so it is not a directory
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
+// dirPathToFile will construct a full path if the given path
+// is a directory. This allows us to also accept directory paths for
+// well-known files (postgresql.conf, pg_config)
+func dirPathToFile(path string, defaultFilename string) string {
+  if len(path) > 0 && pathIsDir(path) {
+    return filepath.Join(path, defaultFilename)
+  }
+  return path
+}
 
 // isCloseEnough checks whether a provided value actual is within +/- the
 // fudge factor fudge of target.


### PR DESCRIPTION
Many PostgreSQL related tools (e.g. pg_config, pg_rewind) have the
interface that you specify the PGDATA directory, or the bin directory.
We can easily offer the same interface as the other tools in the
PostgreSQL ecosystem by appending some defaults iff the path specified
is a directory.