### PR TITLE
WIP, will be rebased: Connect to PostgreSQL

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -33,6 +33,7 @@ func init() {
 	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
 	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
 	flag.StringVar(&f.PGVersion, "pg-version", "", "Major version of PostgreSQL to base recommendations on. Default is determined via pg_config. Valid values: "+strings.Join(tstune.ValidPGVersions, ", "))
+	flag.StringVar(&f.ConnStr, "server", "", "Connection string to connect to PostgreSQL")
 	flag.Uint64Var(&f.MaxConns, "max-conns", 0, "Max number of connections for the database. Default is equal to our best recommendation")
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")


### PR DESCRIPTION
Relying on a single file for determining the PostgreSQL settings is not
enough to know which settings will take effect.
PostgreSQL has configuration includes[1] that are not taken into account
when only reading the main configuration file.

By connecting to PostgreSQL and reading all the relevant settings from
pg_settings, we can avoid duplicating all of this include logic and
leave all the parsing of configuration files to PostgreSQL.

Allowing a connection string to get the source of the configuration also
allows to run this tool on a remote system and write configuration files
locally; this can be very useful if the output of timescaledb-tune is
supposed to be part of configuration management (e.g. Ansible, puppet)

[1] https://www.postgresql.org/docs/current/config-setting.html#CONFIG-INCLUDES