### PR TITLE
Add autovacuum recommendations

### DIFF
--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -209,7 +209,7 @@ func TestMemoryRecommenderRecommend(t *testing.T) {
 		for cpus, connMatrix := range cpuMatrix {
 			for conns, cases := range connMatrix {
 				mr := NewMemoryRecommender(totalMemory, cpus, conns)
-				testRecommender(t, mr, cases)
+				testRecommender(t, mr, MemoryKeys, cases)
 			}
 		}
 	}

--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -10,17 +10,21 @@ import (
 
 // Keys in the conf file that are tunable but not in the other groupings
 const (
-	CheckpointKey     = "checkpoint_completion_target"
-	StatsTargetKey    = "default_statistics_target"
-	MaxConnectionsKey = "max_connections"
-	RandomPageCostKey = "random_page_cost"
-	MaxLocksPerTxKey  = "max_locks_per_transaction"
-	EffectiveIOKey    = "effective_io_concurrency" // linux only
+	CheckpointKey           = "checkpoint_completion_target"
+	StatsTargetKey          = "default_statistics_target"
+	MaxConnectionsKey       = "max_connections"
+	RandomPageCostKey       = "random_page_cost"
+	MaxLocksPerTxKey        = "max_locks_per_transaction"
+	AutovacuumMaxWorkersKey = "autovacuum_max_workers"
+	AutovacuumNaptimeKey    = "autovacuum_naptime"
+	EffectiveIOKey          = "effective_io_concurrency" // linux only
 
-	checkpointDefault     = "0.9"
-	statsTargetDefault    = "500"
-	randomPageCostDefault = "1.1"
-	effectiveIODefault    = "200"
+	checkpointDefault           = "0.9"
+	statsTargetDefault          = "500"
+	randomPageCostDefault       = "1.1"
+	autovacuumMaxWorkersDefault = "10"
+	autovacuumNaptimeDefault    = "10"
+	effectiveIODefault          = "200"
 )
 
 // MaxConnectionsDefault is the recommended default value for max_connections.
@@ -44,6 +48,8 @@ var MiscKeys = []string{
 	CheckpointKey,
 	MaxConnectionsKey,
 	MaxLocksPerTxKey,
+	AutovacuumMaxWorkersKey,
+	AutovacuumNaptimeKey,
 	EffectiveIOKey,
 }
 
@@ -87,6 +93,10 @@ func (r *MiscRecommender) Recommend(key string) string {
 			}
 		}
 		return maxLocksValues[0]
+	} else if key == AutovacuumMaxWorkersKey {
+		val = autovacuumMaxWorkersDefault
+	} else if key == AutovacuumNaptimeKey {
+		val = autovacuumNaptimeDefault
 	} else if key == EffectiveIOKey {
 		val = effectiveIODefault
 	} else {

--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -48,6 +48,8 @@ func init() {
 			miscSettingsMatrix[mem][conns][StatsTargetKey] = statsTargetDefault
 			miscSettingsMatrix[mem][conns][RandomPageCostKey] = randomPageCostDefault
 			miscSettingsMatrix[mem][conns][EffectiveIOKey] = effectiveIODefault
+			miscSettingsMatrix[mem][conns][AutovacuumMaxWorkersKey] = autovacuumMaxWorkersDefault
+			miscSettingsMatrix[mem][conns][AutovacuumNaptimeKey] = autovacuumNaptimeDefault
 		}
 	}
 }
@@ -77,7 +79,7 @@ func TestMiscRecommenderRecommend(t *testing.T) {
 	for totalMemory, outerMatrix := range miscSettingsMatrix {
 		for maxConns, matrix := range outerMatrix {
 			r := &MiscRecommender{totalMemory, maxConns}
-			testRecommender(t, r, matrix)
+			testRecommender(t, r, MiscKeys, matrix)
 		}
 	}
 }

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -62,7 +62,7 @@ func TestParallelRecommenderIsAvailable(t *testing.T) {
 func TestParallelRecommenderRecommend(t *testing.T) {
 	for cpus, matrix := range parallelSettingsMatrix {
 		r := &ParallelRecommender{cpus}
-		testRecommender(t, r, matrix)
+		testRecommender(t, r, ParallelKeys, matrix)
 	}
 }
 

--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -123,12 +123,20 @@ func testSettingGroup(t *testing.T, sg SettingsGroup, cases map[string]string, w
 		}
 		r := sg.GetRecommender()
 
-		testRecommender(t, r, cases)
+		testRecommender(t, r, sg.Keys(), cases)
 	}
 }
 
-func testRecommender(t *testing.T, r Recommender, cases map[string]string) {
-	for key, want := range cases {
+// testRecommender is a helper method for testing whether a Recommender gives
+// the appropriate values for a set of keys.
+//
+// Rather than iterating over the 'wants' map to get the keys, we iterate over
+// a separate 'keys' parameter that should include _all_ keys a Recommender
+// handles. This makes sure that when new keys are added, our tests are comprehensive,
+// since otherwise the Recommender will panic on an unknown key.
+func testRecommender(t *testing.T, r Recommender, keys []string, wants map[string]string) {
+	for _, key := range keys {
+		want := wants[key]
 		if got := r.Recommend(key); got != want {
 			t.Errorf("%v: incorrect result for key %s: got\n%s\nwant\n%s", r, key, got, want)
 		}

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -50,7 +50,7 @@ func TestNewWALRecommender(t *testing.T) {
 func TestWALRecommenderRecommend(t *testing.T) {
 	for totalMemory, matrix := range walSettingsMatrix {
 		r := &WALRecommender{totalMemory}
-		testRecommender(t, r, matrix)
+		testRecommender(t, r, WALKeys, matrix)
 	}
 }
 

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version is the version of this library
-	Version = "0.6.0"
+	Version = "0.7.0-dev"
 
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1279,6 +1279,8 @@ var (
 		"random_page_cost = 1.1",
 		"checkpoint_completion_target = 0.9",
 		fmt.Sprintf("max_connections = %d", pgtune.MaxConnectionsDefault),
+		"autovacuum_max_workers = 10",
+		"autovacuum_naptime = 10",
 		"max_locks_per_transaction = 64",
 		"effective_io_concurrency = 200",
 		"max_locks_per_transaction = 128",


### PR DESCRIPTION
The default max of autovacuum workers and their naptime can be a
bottleneck when a database has many chunks that need to be vacuumed
and analyzed. Also, if some chunks are larger than others, it may
end blocking smaller chunks from getting processed in a timely
fashion as the system is waiting for autovacuum workers to be freed
up.