### PR TITLE
Add flag for specifying the size of the WAL disk

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -33,6 +33,7 @@ func init() {
 	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
 	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
 	flag.StringVar(&f.PGVersion, "pg-version", "", "Major version of PostgreSQL to base recommendations on. Default is determined via pg_config. Valid values: "+strings.Join(tstune.ValidPGVersions, ", "))
+	flag.StringVar(&f.WALDiskSize, "wal-disk-size", "", "Size of the disk where the WAL resides, in PostgreSQL format <int value><units>, e.g., 4GB. Using this flag helps tune WAL behavior.")
 	flag.Uint64Var(&f.MaxConns, "max-conns", 0, "Max number of connections for the database. Default is equal to our best recommendation")
 	flag.StringVar(&f.ConfPath, "conf-path", "", "Path to postgresql.conf. If blank, heuristics will be used to find it")
 	flag.StringVar(&f.DestPath, "out-path", "", "Path to write the new configuration file. If blank, will use the same file that is read from")

--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -99,7 +99,7 @@ func TestMiscRecommenderRecommendPanic(t *testing.T) {
 func TestMiscSettingsGroup(t *testing.T) {
 	for totalMemory, outerMatrix := range miscSettingsMatrix {
 		for maxConns, matrix := range outerMatrix {
-			config, err := NewSystemConfig(totalMemory, 8, "10", maxConns)
+			config, err := NewSystemConfig(totalMemory, 8, "10", walDiskUnset, maxConns)
 			if err != nil {
 				t.Errorf("unexpected error on system config creation: got %v", err)
 			}

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -39,11 +39,12 @@ type SystemConfig struct {
 	Memory         uint64
 	CPUs           int
 	PGMajorVersion string
+	WALDiskSize    uint64
 	maxConns       uint64
 }
 
 // NewSystemConfig returns a new SystemConfig with the given parameters.
-func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, maxConns uint64) (*SystemConfig, error) {
+func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, walDiskSize uint64, maxConns uint64) (*SystemConfig, error) {
 	if maxConns != 0 && maxConns < minMaxConns {
 		return nil, fmt.Errorf(errMaxConnsTooLowFmt, minMaxConns, maxConns)
 	}
@@ -51,6 +52,7 @@ func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, maxConns ui
 		Memory:         totalMemory,
 		CPUs:           cpus,
 		PGMajorVersion: pgVersion,
+		WALDiskSize:    walDiskSize,
 		maxConns:       maxConns,
 	}, nil
 }
@@ -64,7 +66,7 @@ func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 	case label == ParallelLabel:
 		return &ParallelSettingsGroup{config.PGMajorVersion, config.CPUs}
 	case label == WALLabel:
-		return &WALSettingsGroup{config.Memory}
+		return &WALSettingsGroup{config.Memory, config.WALDiskSize}
 	case label == MiscLabel:
 		return &MiscSettingsGroup{config.Memory, config.maxConns}
 	}


### PR DESCRIPTION
Previously the values for min_wal_size and max_wal_size could be
too aggressive for machines with shared WAL and data disks or with
small WAL disks. To that end, this PR introduces a new flag for
specifying the size of the WAL disk (or, the amount of disk space
reserved for the WAL) to base calculations on. The max_wal_size
will be up to 80% of the space given. The min_wal_size is set to
half of the max. If the flag is empty, the default WAL values for
PostgreSQL are used.