### PR TITLE
Allow sizes to be specified without suffix (bytes)

### DIFF
--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -23,7 +23,7 @@ const (
 	GB = "GB"    // gigabyte
 	MB = "MB"    // megabyte
 	KB = "kB"    // kilobyte
-	B  = "bytes" // for completeness, not used in PostgreSQL
+	B  = ""      // no unit, therefore: bytes
 )
 
 const (
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	pgBytesRegex   = regexp.MustCompile("^([0-9]+)((?:k|M|G|T)B)$")
+	pgBytesRegex   = regexp.MustCompile("^([0-9]+)((?:k|M|G|T)B)?$")
 	pgVersionRegex = regexp.MustCompile("^PostgreSQL ([0-9]+?).([0-9]+?).*")
 )
 
@@ -114,6 +114,8 @@ func PGFormatToBytes(val string) (uint64, error) {
 		ret = uint64(num) * Gigabyte
 	} else if units == TB {
 		ret = uint64(num) * Terabyte
+	} else if units == B {
+		ret = uint64(num)
 	} else {
 		return 0, fmt.Errorf("unknown units: %s", units)
 	}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -296,6 +296,11 @@ func TestPGFormatToBytes(t *testing.T) {
 			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "5.5"+MB),
 		},
 		{
+			desc:  "valid bytes",
+			input: "65536" + B,
+			want:  64 * Kilobyte,
+		},
+		{
 			desc:  "valid kilobytes",
 			input: "64" + KB,
 			want:  64 * Kilobyte,


### PR DESCRIPTION
In some environments, for example k8s, we can pass along Memory or Disk
sizes directly, however currently we need to ensure we add a suffix to
these sizes, as the tool requires a unit specifier.

The pg_size_bytes function of PostgreSQL also allows the same behaviour,
defaulting to bytes if no unit is specified.

The previous definition of B (bytes) already resulted in an error
message and was therefore unusable.