### PR TITLE
Allow to fallthrough on PG12

### DIFF
--- a/pkg/pgutils/utils.go
+++ b/pkg/pgutils/utils.go
@@ -13,6 +13,7 @@ const (
 	MajorVersion96 = "9.6"
 	MajorVersion10 = "10"
 	MajorVersion11 = "11"
+	MajorVersion12 = "12"
 )
 
 const (
@@ -43,6 +44,8 @@ func ToPGMajorVersion(val string) (string, error) {
 		return "", fmt.Errorf(errCouldNotParseVersionFmt, val)
 	}
 	switch res[1] {
+	case MajorVersion12:
+		fallthrough
 	case MajorVersion11:
 		fallthrough
 	case MajorVersion10:

--- a/pkg/tstune/utils.go
+++ b/pkg/tstune/utils.go
@@ -12,6 +12,7 @@ import (
 // ValidPGVersions is a slice representing the major versions of PostgreSQL
 // for which recommendations can be generated.
 var ValidPGVersions = []string{
+	pgutils.MajorVersion12,
 	pgutils.MajorVersion11,
 	pgutils.MajorVersion10,
 	pgutils.MajorVersion96,

--- a/pkg/tstune/utils_test.go
+++ b/pkg/tstune/utils_test.go
@@ -115,6 +115,7 @@ func TestGetPGMajorVersion(t *testing.T) {
 	okPath96 := "pg_config_9.6"
 	okPath10 := "pg_config_10"
 	okPath11 := "pg_config_11"
+	okPath12 := "pg_config_12"
 	okPath95 := "pg_config_9.5"
 	okPath60 := "pg_config_6.0"
 	cases := []struct {
@@ -153,6 +154,11 @@ func TestGetPGMajorVersion(t *testing.T) {
 			binPath: okPath11,
 			want:    pgutils.MajorVersion11,
 		},
+		{
+			desc:    "success 12",
+			binPath: okPath12,
+			want:    pgutils.MajorVersion12,
+		},
 	}
 
 	oldVersionFn := getPGConfigVersionFn
@@ -168,6 +174,8 @@ func TestGetPGMajorVersion(t *testing.T) {
 			return "PostgreSQL 10.5 (Debian7)", nil
 		case okPath11:
 			return "PostgreSQL 11.1", nil
+		case okPath12:
+			return "PostgreSQL 12.1", nil
 		default:
 			return "", exec.ErrNotFound
 		}
@@ -200,7 +208,8 @@ func TestValidatePGMajorVersion(t *testing.T) {
 		pgutils.MajorVersion96: true,
 		pgutils.MajorVersion10: true,
 		pgutils.MajorVersion11: true,
-		"12":                   false,
+		pgutils.MajorVersion12: true,
+		"13":                   false,
 		"9.5":                  false,
 		"1.2.3":                false,
 		"9.6.6":                false,


### PR DESCRIPTION
## Why

See https://github.com/timescale/timescaledb-tune/issues/61

## Tests
```
$ go test ./...
?   	github.com/timescale/timescaledb-tune/cmd/timescaledb-tune	[no test files]
ok  	github.com/timescale/timescaledb-tune/internal/parse	0.740s
ok  	github.com/timescale/timescaledb-tune/pkg/pgtune	1.000s
ok  	github.com/timescale/timescaledb-tune/pkg/pgutils	0.577s
ok  	github.com/timescale/timescaledb-tune/pkg/tstune	0.045s
```

## Additional Notes
Not sure if this is needed upstream, but these edits allowed us to run the tuner on our deployment