### PR TITLE
Change max_wal_size to only be 60% of WAL disk

### DIFF
--- a/pkg/pgtune/wal.go
+++ b/pkg/pgtune/wal.go
@@ -12,6 +12,7 @@ const (
 	MinWALKey     = "min_wal_size"
 	MaxWALKey     = "max_wal_size"
 
+	walMaxDiskPct       = 60 // max_wal_size should be 60% of the WAL disk
 	walBuffersThreshold = 2 * parse.Gigabyte
 	walBuffersDefault   = 16 * parse.Megabyte
 	defaultMaxWALBytes  = 1 * parse.Gigabyte
@@ -76,9 +77,9 @@ func (r *WALRecommender) calcMaxWALBytes() uint64 {
 		return defaultMaxWALBytes
 	}
 
-	// With size given, we want to take up at most 80% of it, to give
+	// With size given, we want to take up at most walMaxDiskPct, to give
 	// additional room for safety.
-	max := uint64(r.walDiskSize*80) / 100
+	max := uint64(r.walDiskSize*walMaxDiskPct) / 100
 
 	// WAL segments are 16MB, so it doesn't make sense not to round
 	// up to the nearest 16MB boundary.

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -10,7 +10,7 @@ import (
 const (
 	walDiskUnset          = 0
 	walDiskDivideUnevenly = 8 * parse.Gigabyte
-	walDiskDivideEvenly   = 8500 * parse.Megabyte
+	walDiskDivideEvenly   = 8800 * parse.Megabyte
 )
 
 // memoryToWALBuffers provides a mapping from test case memory levels to the
@@ -25,8 +25,8 @@ var memoryToWALBuffers = map[uint64]uint64{
 
 var walDiskToMaxBytes = map[uint64]uint64{
 	walDiskUnset:          defaultMaxWALBytes,
-	walDiskDivideUnevenly: 6560 * parse.Megabyte, // nearest 16MB segment
-	walDiskDivideEvenly:   6800 * parse.Megabyte,
+	walDiskDivideUnevenly: 4928 * parse.Megabyte, // nearest 16MB segment
+	walDiskDivideEvenly:   5280 * parse.Megabyte,
 }
 
 // walSettingsMatrix stores the test cases for WALRecommender along with the


### PR DESCRIPTION
To err on the side of caution, we reduce the max_wal_size to be
60% of the WAL disk size. 80% was a bit high and probably where
one would set alerts, so we want to be a bit below that range.