### PR TITLE
Allow major PG version 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@
 [TimescaleDB](//github.com/timescale/timescaledb) database to perform
 its best based on the host's resources such as memory and number of CPUs.
 It parses the existing `postgresql.conf` file to ensure that the TimescaleDB
-extension is appropriately installed and provides recommendations for memory,
-parallelism, WAL, and other settings.
+extension is appropriately installed and provides recommendations for
+memory, parallelism, WAL, and other settings.
 
 ### Getting started
-You need the Go runtime (1.10+) installed, then simply `go get` this repo:
+You need the Go runtime (1.12+) installed, then simply `go get` this repo:
 ```bash
 $ go get github.com/timescale/timescaledb-tune/cmd/timescaledb-tune
 ```
 
+It is also available as a binary package on a variety systems using
+Homebrew, `yum`, or `apt`. Search for `timescaledb-tools`.
+
 ### Using timescaledb-tune
-By default, `timescaledb-tune` attempts to locate your `postgresql.conf` file
-for parsing by using heuristics based on the operating system, so the simplest
-invocation would be:
+By default, `timescaledb-tune` attempts to locate your `postgresql.conf`
+file for parsing by using heuristics based on the operating system, so the
+simplest invocation would be:
 ```bash
 $ timescaledb-tune
 ```
@@ -57,20 +60,26 @@ Is this okay? [(y)es/(s)kip/(q)uit]:
 ```
 
 If you have moved the configuration file to a different location, or
-auto-detection fails (file an issue please!), you can provide the location with
-the `--conf-path` flag:
+auto-detection fails (file an issue please!), you can provide the location
+with the `--conf-path` flag:
 ```bash
 $ timescaledb-tune --conf-path=/path/to/postgresql.conf
 ```
 
-At the end, your `postgresql.conf` will be overwritten with the changes that you
-accepted from the prompts.
+At the end, your `postgresql.conf` will be overwritten with the changes
+that you accepted from the prompts.
 
 #### Other invocations
 
 If you want recommendations for a specific amount of memory and/or CPUs:
 ```bash
 $ timescaledb-tune --memory="4GB" --cpus=2
+```
+
+If you have a dedicated disk for WAL, or want to specify how much of a
+shared disk should be used for WAL:
+```bash
+$ timescaledb-tune --wal-disk-size="10GB"
 ```
 
 If you want to accept all recommendations, you can use `--yes`:
@@ -101,10 +110,10 @@ $ timescaledb-tune --quiet --yes --dry-run >> /path/to/postgresql.conf
 
 ### Restoring backups
 
-`timescaledb-tune` makes a backup of your `postgresql.conf` file each time it
-runs (without the `--dry-run` flag) in your temp directory. If you find that
-the configuration given is not working well, you can restore a backup by
-using the `--restore` flag:
+`timescaledb-tune` makes a backup of your `postgresql.conf` file each time
+it runs (without the `--dry-run` flag) in your temp directory. If you find
+that the configuration given is not working well, you can restore a backup
+by using the `--restore` flag:
 ```bash
 $ timescaledb-tune --restore
 ```
@@ -125,4 +134,6 @@ success: restored successfully
 ```
 
 ### Contributing
-We welcome contributions to this utility, which like TimescaleDB is released under the Apache2 Open Source License.  The same [Contributors Agreement](//github.com/timescale/timescaledb/blob/master/CONTRIBUTING.md) applies; please sign the [Contributor License Agreement](https://cla-assistant.io/timescale/timescaledb-tune) (CLA) if you're a new contributor.
+We welcome contributions to this utility, which like TimescaleDB is
+released under the Apache2 Open Source License.  The same [Contributors Agreement](//github.com/timescale/timescaledb/blob/master/CONTRIBUTING.md)
+applies; please sign the [Contributor License Agreement](https://cla-assistant.io/timescale/timescaledb-tune) (CLA) if you're a new contributor.

--- a/pkg/pgutils/utils.go
+++ b/pkg/pgutils/utils.go
@@ -13,6 +13,7 @@ const (
 	MajorVersion96 = "9.6"
 	MajorVersion10 = "10"
 	MajorVersion11 = "11"
+	MajorVersion12 = "12"
 )
 
 const (
@@ -43,15 +44,9 @@ func ToPGMajorVersion(val string) (string, error) {
 		return "", fmt.Errorf(errCouldNotParseVersionFmt, val)
 	}
 	switch res[1] {
-	case MajorVersion11:
-		fallthrough
-	case MajorVersion10:
+	case MajorVersion10, MajorVersion11, MajorVersion12:
 		return res[1], nil
-	case "9":
-		fallthrough
-	case "8":
-		fallthrough
-	case "7":
+	case "7", "8", "9":
 		return res[1] + "." + res[2], nil
 	default:
 		return "", fmt.Errorf(errUnknownMajorVersionFmt, val)

--- a/pkg/pgutils/utils_test.go
+++ b/pkg/pgutils/utils_test.go
@@ -14,6 +14,16 @@ func TestToPGMajorVersion(t *testing.T) {
 		errMsg  string
 	}{
 		{
+			desc:    "pg12",
+			version: okPrefix + "12.4",
+			want:    "12",
+		},
+		{
+			desc:    "pg12 w/ extra",
+			version: okPrefix + "12.4 (Debian 10.1+foo)",
+			want:    "12",
+		},
+		{
 			desc:    "pg11",
 			version: okPrefix + "11.1",
 			want:    "11",

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version is the version of this library
-	Version = "0.8.0"
+	Version = "0.8.1"
 
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"

--- a/pkg/tstune/utils.go
+++ b/pkg/tstune/utils.go
@@ -3,8 +3,8 @@ package tstune
 import (
 	"fmt"
 	"math"
-	"path/filepath"
 	"os"
+	"path/filepath"
 
 	"github.com/timescale/timescaledb-tune/pkg/pgutils"
 )
@@ -12,6 +12,7 @@ import (
 // ValidPGVersions is a slice representing the major versions of PostgreSQL
 // for which recommendations can be generated.
 var ValidPGVersions = []string{
+	pgutils.MajorVersion12,
 	pgutils.MajorVersion11,
 	pgutils.MajorVersion10,
 	pgutils.MajorVersion96,
@@ -34,7 +35,7 @@ func fileExists(name string) bool {
 }
 
 func pathIsDir(name string) bool {
-	fi, err := osStatFn(name);
+	fi, err := osStatFn(name)
 	// for our purposes, any error is a problem, so it is not a directory
 	if err != nil {
 		return false
@@ -46,10 +47,10 @@ func pathIsDir(name string) bool {
 // is a directory. This allows us to also accept directory paths for
 // well-known files (postgresql.conf, pg_config)
 func dirPathToFile(path string, defaultFilename string) string {
-  if len(path) > 0 && pathIsDir(path) {
-    return filepath.Join(path, defaultFilename)
-  }
-  return path
+	if len(path) > 0 && pathIsDir(path) {
+		return filepath.Join(path, defaultFilename)
+	}
+	return path
 }
 
 // isCloseEnough checks whether a provided value actual is within +/- the

--- a/pkg/tstune/utils_test.go
+++ b/pkg/tstune/utils_test.go
@@ -115,6 +115,7 @@ func TestGetPGMajorVersion(t *testing.T) {
 	okPath96 := "pg_config_9.6"
 	okPath10 := "pg_config_10"
 	okPath11 := "pg_config_11"
+	okPath12 := "pg_config_12"
 	okPath95 := "pg_config_9.5"
 	okPath60 := "pg_config_6.0"
 	cases := []struct {
@@ -153,6 +154,11 @@ func TestGetPGMajorVersion(t *testing.T) {
 			binPath: okPath11,
 			want:    pgutils.MajorVersion11,
 		},
+		{
+			desc:    "success 12",
+			binPath: okPath12,
+			want:    pgutils.MajorVersion12,
+		},
 	}
 
 	oldVersionFn := getPGConfigVersionFn
@@ -168,6 +174,8 @@ func TestGetPGMajorVersion(t *testing.T) {
 			return "PostgreSQL 10.5 (Debian7)", nil
 		case okPath11:
 			return "PostgreSQL 11.1", nil
+		case okPath12:
+			return "PostgreSQL 12.4", nil
 		default:
 			return "", exec.ErrNotFound
 		}
@@ -200,7 +208,8 @@ func TestValidatePGMajorVersion(t *testing.T) {
 		pgutils.MajorVersion96: true,
 		pgutils.MajorVersion10: true,
 		pgutils.MajorVersion11: true,
-		"12":                   false,
+		pgutils.MajorVersion12: true,
+		"13":                   false,
 		"9.5":                  false,
 		"1.2.3":                false,
 		"9.6.6":                false,


### PR DESCRIPTION
With the release of TimescaleDB 1.7, we now support PG12 so tune
should no longer consider it unsupported.