### PR TITLE
Update max_connections calculation

### DIFF
--- a/pkg/pgtune/memory.go
+++ b/pkg/pgtune/memory.go
@@ -47,7 +47,7 @@ type MemoryRecommender struct {
 func NewMemoryRecommender(totalMemory uint64, cpus int, maxConns uint64) *MemoryRecommender {
 	conns := maxConns
 	if conns == 0 {
-		conns = MaxConnectionsDefault
+		conns = getMaxConns(totalMemory)
 	}
 	return &MemoryRecommender{totalMemory, cpus, conns}
 }

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -8,8 +8,6 @@ import "fmt"
 const (
 	osWindows            = "windows"
 	errMaxConnsTooLowFmt = "maxConns must be 0 OR >= %d: got %d"
-
-	minMaxConns = 10
 )
 
 // Recommender is an interface that gives setting recommendations for a given

--- a/pkg/pgtune/tune_test.go
+++ b/pkg/pgtune/tune_test.go
@@ -9,7 +9,7 @@ import (
 const (
 	testMaxConnsSpecial = 0
 	testMaxConnsBad     = 1
-	testMaxConns        = 10
+	testMaxConns        = minMaxConns
 )
 
 func getDefaultTestSystemConfig(t *testing.T) *SystemConfig {
@@ -119,6 +119,8 @@ func TestGetSettingsGroup(t *testing.T) {
 }
 
 func testSettingGroup(t *testing.T, sg SettingsGroup, cases map[string]string, wantLabel string, wantKeys []string) {
+	t.Helper()
+
 	// No matter how many calls, all calls should return the same
 	for i := 0; i < 1000; i++ {
 		if got := sg.Label(); got != wantLabel {
@@ -147,6 +149,8 @@ func testSettingGroup(t *testing.T, sg SettingsGroup, cases map[string]string, w
 // handles. This makes sure that when new keys are added, our tests are comprehensive,
 // since otherwise the Recommender will panic on an unknown key.
 func testRecommender(t *testing.T, r Recommender, keys []string, wants map[string]string) {
+	t.Helper()
+
 	for _, key := range keys {
 		want := wants[key]
 		if got := r.Recommend(key); got != want {

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version is the version of this library
-	Version = "0.8.1"
+	Version = "0.9.0"
 
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1025,6 +1025,13 @@ var (
 	}
 )
 
+const (
+	testMaxConns        = 20
+	testMem      uint64 = 8 * parse.Gigabyte
+	testCPUs            = 4
+	testWALDisk  uint64 = 0
+)
+
 type testSettingsGroup struct {
 	keys []string
 }
@@ -1034,11 +1041,7 @@ func (sg *testSettingsGroup) Keys() []string                     { return sg.key
 func (sg *testSettingsGroup) GetRecommender() pgtune.Recommender { return &badRecommender{} }
 
 func getDefaultSystemConfig(t *testing.T) *pgtune.SystemConfig {
-	mem := uint64(8 * parse.Gigabyte)
-	cpus := 4
-	var maxConns uint64 = 20
-	var walDisk uint64 = 0
-	config, err := pgtune.NewSystemConfig(mem, cpus, pgutils.MajorVersion10, walDisk, maxConns)
+	config, err := pgtune.NewSystemConfig(testMem, testCPUs, pgutils.MajorVersion10, testWALDisk, testMaxConns)
 	if err != nil {
 		t.Fatalf("unexpected error in config creation: got %v", err)
 	}
@@ -1300,7 +1303,7 @@ var (
 		"default_statistics_target = 500",
 		"random_page_cost = 1.1",
 		"checkpoint_completion_target = 0.9",
-		fmt.Sprintf("max_connections = %d", pgtune.MaxConnectionsDefault),
+		fmt.Sprintf("max_connections = %d", testMaxConns),
 		"autovacuum_max_workers = 10",
 		"autovacuum_naptime = 10",
 		"max_locks_per_transaction = 64",


### PR DESCRIPTION
The default of 100 for max_connections can be a bit high for
instances with less memory; work_mem would be smaller and thus
cause more queries to spill to disk than necessary. This change
creates a step function to allow for smaller max_connection values
for memory sizes below 6GB. A user can still override to a higher
amount using the appropriate flag.

Additionally, this PR fixes a problem with user set max_connections
where the user's value would be used for memory calculations, but
would not necessarily be used for the actual max_connections value.
Previously, if the user's max_connections value was smaller than
the default, the memory calculation would use it to determine the
appropriate work_mem, but ultimately the default max_connections
would be set in the config file. This could lead to incorrect
behavior and overcommitment of memory.