### PR TITLE
Update effective_io_concurrency value for v13

### DIFF
--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -28,7 +28,7 @@ const (
 	// see https://www.postgresql.org/docs/13/release-13.html
 	// on how to translate between the old and the new value.
 	effectiveIODefaultOldVersions = "200"
-	effectiveIODefault            = "11176"
+	effectiveIODefault            = "1176"
 
 	minMaxConns = 20
 )

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -72,7 +72,7 @@ func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 	case label == WALLabel:
 		return &WALSettingsGroup{config.Memory, config.WALDiskSize}
 	case label == MiscLabel:
-		return &MiscSettingsGroup{config.Memory, config.maxConns}
+		return &MiscSettingsGroup{config.Memory, config.maxConns, config.PGMajorVersion}
 	}
 	panic("unknown label: " + label)
 }

--- a/pkg/pgutils/utils.go
+++ b/pkg/pgutils/utils.go
@@ -8,8 +8,6 @@ import (
 
 // Major version strings for recent PostgreSQL versions
 const (
-	MajorVersion94 = "9.4"
-	MajorVersion95 = "9.5"
 	MajorVersion96 = "9.6"
 	MajorVersion10 = "10"
 	MajorVersion11 = "11"


### PR DESCRIPTION
In Postgres 13, the way how Postgres uses the effective_io_concurrency
value has changed. See https://www.postgresql.org/docs/13/release-13.html
for the conversion between the old and the new one and
https://www.postgresql.org/message-id/CA%2BhUKGJUw08dPs_3EUcdO6M90GnjofPYrWp4YSLaBkgYwS-AqA%40mail.gmail.com
for the background.