### PR TITLE
Support for tuning with less than 1 CPU

### DIFF
--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -33,6 +33,7 @@ var (
 func init() {
 	flag.StringVar(&f.Memory, "memory", "", "Amount of memory to base recommendations on in the PostgreSQL format <int value><units>, e.g., 4GB. Default is to use all memory")
 	flag.UintVar(&f.NumCPUs, "cpus", 0, "Number of CPU cores to base recommendations on. Default is equal to number of cores")
+	flag.UintVar(&f.NumMilliCPUs, "milli-cpus", 0, "Number of milli CPU cores to base recommendations on (replaces numCPUs). Default is 0")
 	flag.StringVar(&f.PGVersion, "pg-version", "", "Major version of PostgreSQL to base recommendations on. Default is determined via pg_config. Valid values: "+strings.Join(tstune.ValidPGVersions, ", "))
 	flag.StringVar(&f.WALDiskSize, "wal-disk-size", "", "Size of the disk where the WAL resides, in PostgreSQL format <int value><units>, e.g., 4GB. Using this flag helps tune WAL behavior.")
 	flag.Uint64Var(&f.MaxConns, "max-conns", 0, "Max number of connections for the database. Default is equal to our best recommendation")

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -19,23 +19,20 @@ const (
 
 // Suffixes for byte measurements that are valid to PostgreSQL
 const (
-	TB = "TB"    // terabyte
-	GB = "GB"    // gigabyte
-	MB = "MB"    // megabyte
-	KB = "kB"    // kilobyte
-	B  = ""      // no unit, therefore: bytes
+	TB = "TB" // terabyte
+	GB = "GB" // gigabyte
+	MB = "MB" // megabyte
+	KB = "kB" // kilobyte
+	B  = ""   // no unit, therefore: bytes
 )
 
 const (
-	errIncorrectFormatFmt      = "incorrect PostgreSQL bytes format: '%s'"
-	errCouldNotParseBytesFmt   = "could not parse bytes number: %v"
-	errCouldNotParseVersionFmt = "unable to parse PG version string: %s"
-	errUnknownMajorVersionFmt  = "unknown major PG version: %s"
+	errIncorrectFormatFmt    = "incorrect PostgreSQL bytes format: '%s'"
+	errCouldNotParseBytesFmt = "could not parse bytes number: %v"
 )
 
 var (
-	pgBytesRegex   = regexp.MustCompile("^([0-9]+)((?:k|M|G|T)B)?$")
-	pgVersionRegex = regexp.MustCompile("^PostgreSQL ([0-9]+?).([0-9]+?).*")
+	pgBytesRegex = regexp.MustCompile("^([0-9]+)((?:k|M|G|T)B)?$")
 )
 
 func parseIntToFloatUnits(bytes uint64) (float64, string) {

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -87,7 +87,7 @@ func TestNewMemoryRecommender(t *testing.T) {
 		milliCPus := rand.Intn(128) * pgutils.MilliScaleFactor
 		r := NewMemoryRecommender(mem, milliCPus, MaxConnectionsDefault)
 		if r == nil {
-			t.Errorf("unexpected nil recommender")
+			t.Fatalf("unexpected nil recommender")
 		}
 		if got := r.totalMemory; got != mem {
 			t.Errorf("recommender has incorrect memory: got %d want %d", got, mem)

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/timescale/timescaledb-tune/internal/parse"
+	"github.com/timescale/timescaledb-tune/pkg/pgutils"
 )
 
 // memoryToBaseVals provides a memory from test memory levels to expected "base"
@@ -36,11 +37,11 @@ var memoryToBaseVals = map[uint64]map[string]uint64{
 
 // highCPUs is the number of CPUs that is high enough that work_mem would normally
 // fall below the minimum (64KB) using the standard formula
-const highCPUs = 9000
+const highMilliCPUs = 9000 * pgutils.MilliScaleFactor
 
 var (
 	// cpuVals is the different amounts of CPUs to test
-	cpuVals = []int{1, 4, 5, highCPUs}
+	milliCPUVals = []int{1 * pgutils.MilliScaleFactor, 4 * pgutils.MilliScaleFactor, 5 * pgutils.MilliScaleFactor, highMilliCPUs, 500, 100}
 	// connVals is the different number of conns to test
 	connVals = []uint64{0, 19, 20, 50}
 	// memorySettingsMatrix stores the test cases for MemoryRecommend along with
@@ -51,28 +52,28 @@ var (
 func init() {
 	for mem, baseMatrix := range memoryToBaseVals {
 		memorySettingsMatrix[mem] = make(map[int]map[uint64]map[string]string)
-		for _, cpus := range cpuVals {
-			memorySettingsMatrix[mem][cpus] = make(map[uint64]map[string]string)
+		for _, milliCPUs := range milliCPUVals {
+			memorySettingsMatrix[mem][milliCPUs] = make(map[uint64]map[string]string)
 			for _, conns := range connVals {
-				memorySettingsMatrix[mem][cpus][conns] = make(map[string]string)
+				memorySettingsMatrix[mem][milliCPUs][conns] = make(map[string]string)
 
-				memorySettingsMatrix[mem][cpus][conns][SharedBuffersKey] = parse.BytesToPGFormat(baseMatrix[SharedBuffersKey])
-				memorySettingsMatrix[mem][cpus][conns][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
-				memorySettingsMatrix[mem][cpus][conns][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
+				memorySettingsMatrix[mem][milliCPUs][conns][SharedBuffersKey] = parse.BytesToPGFormat(baseMatrix[SharedBuffersKey])
+				memorySettingsMatrix[mem][milliCPUs][conns][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
+				memorySettingsMatrix[mem][milliCPUs][conns][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
 
-				if cpus == highCPUs {
-					memorySettingsMatrix[mem][cpus][conns][WorkMemKey] = parse.BytesToPGFormat(workMemMin)
+				if milliCPUs == highMilliCPUs {
+					memorySettingsMatrix[mem][milliCPUs][conns][WorkMemKey] = parse.BytesToPGFormat(workMemMin)
 				} else {
 					// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
-					cpuFactor := math.Round(float64(cpus) / 2.0)
-					// Our work_mem values are derivied by a certain amount of memory lost/gained when
+					cpuFactor := math.Max(math.Round(float64(milliCPUs)/(2.0*pgutils.MilliScaleFactor)), 1)
+					// Our work_mem values are derived by a certain amount of memory lost/gained when
 					// moving away from baseConns
 					connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
 					if conns != 0 {
 						connFactor = float64(conns) / float64(baseConns)
 					}
 
-					memorySettingsMatrix[mem][cpus][conns][WorkMemKey] =
+					memorySettingsMatrix[mem][milliCPUs][conns][WorkMemKey] =
 						parse.BytesToPGFormat(uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor))
 				}
 			}
@@ -83,16 +84,16 @@ func init() {
 func TestNewMemoryRecommender(t *testing.T) {
 	for i := 0; i < 1000000; i++ {
 		mem := rand.Uint64()
-		cpus := rand.Intn(128)
-		r := NewMemoryRecommender(mem, cpus, MaxConnectionsDefault)
+		milliCPus := rand.Intn(128) * pgutils.MilliScaleFactor
+		r := NewMemoryRecommender(mem, milliCPus, MaxConnectionsDefault)
 		if r == nil {
 			t.Errorf("unexpected nil recommender")
 		}
 		if got := r.totalMemory; got != mem {
-			t.Errorf("recommender has incorrect cpus: got %d want %d", got, cpus)
+			t.Errorf("recommender has incorrect memory: got %d want %d", got, mem)
 		}
-		if got := r.cpus; got != cpus {
-			t.Errorf("recommender has incorrect cpus: got %d want %d", got, cpus)
+		if got := r.milliCPUs; got != milliCPus {
+			t.Errorf("recommender has incorrect milliCpus: got %d want %d", got, milliCPus)
 		}
 
 		if !r.IsAvailable() {
@@ -105,98 +106,105 @@ func TestMemoryRecommenderRecommendWindows(t *testing.T) {
 	cases := []struct {
 		desc        string
 		totalMemory uint64
-		cpus        int
+		milliCPUs   int
 		conns       uint64
 		want        string
 	}{
 		{
 			desc:        "1GB",
 			totalMemory: 1 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
+			conns:       baseConns,
+			want:        "6553" + parse.KB, // from pgtune
+		},
+		{
+			desc:        "1GB with fractions of CPU",
+			totalMemory: 1 * parse.Gigabyte,
+			milliCPUs:   500,
 			conns:       baseConns,
 			want:        "6553" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "1GB, 10 conns",
 			totalMemory: 1 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
 			conns:       10,
 			want:        "13107" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "1GB, 4 cpus",
 			totalMemory: 1 * parse.Gigabyte,
-			cpus:        4,
+			milliCPUs:   4 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "3276" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "2GB",
 			totalMemory: 2 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "13107" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "2GB, 5 cpus",
 			totalMemory: 2 * parse.Gigabyte,
-			cpus:        5,
+			milliCPUs:   5 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "4369" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "3GB",
 			totalMemory: 3 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "21845" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "3GB, 3 cpus",
 			totalMemory: 3 * parse.Gigabyte,
-			cpus:        3,
+			milliCPUs:   3 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "10922" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "8GB",
 			totalMemory: 8 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "64" + parse.MB, // from pgtune
 		},
 		{
 			desc:        "8GB, 8 cpus",
 			totalMemory: 8 * parse.Gigabyte,
-			cpus:        8,
+			milliCPUs:   8 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "16" + parse.MB, // from pgtune
 		},
 		{
 			desc:        "16GB",
 			totalMemory: 16 * parse.Gigabyte,
-			cpus:        1,
+			milliCPUs:   1 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "135441" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "16GB, 10 cpus",
 			totalMemory: 16 * parse.Gigabyte,
-			cpus:        10,
+			milliCPUs:   10 * pgutils.MilliScaleFactor,
 			conns:       baseConns,
 			want:        "27088" + parse.KB, // from pgtune
 		},
 		{
 			desc:        "1GB, 9000 cpus",
 			totalMemory: parse.Gigabyte,
-			cpus:        highCPUs,
+			milliCPUs:   highMilliCPUs,
 			conns:       baseConns,
 			want:        "64" + parse.KB,
 		},
 	}
 
 	for _, c := range cases {
-		mr := NewMemoryRecommender(c.totalMemory, c.cpus, c.conns)
+		mr := NewMemoryRecommender(c.totalMemory, c.milliCPUs, c.conns)
 		if got := mr.recommendWindows(); got != c.want {
 			t.Errorf("%s: incorrect value: got %s want %s", c.desc, got, c.want)
 		}
@@ -231,7 +239,7 @@ func TestMemorySettingsGroup(t *testing.T) {
 		for cpus, connMatrix := range cpuMatrix {
 			for conns, matrix := range connMatrix {
 				config := getDefaultTestSystemConfig(t)
-				config.CPUs = cpus
+				config.MilliCPUs = cpus
 				config.Memory = totalMemory
 				config.maxConns = conns
 

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -64,7 +64,7 @@ func TestNewParallelRecommender(t *testing.T) {
 		workers := rand.Intn(128-MaxBackgroundWorkersDefault+1) + MaxBackgroundWorkersDefault
 		r := NewParallelRecommender(milliCPUs, workers)
 		if r == nil {
-			t.Errorf("unexpected nil recommender")
+			t.Fatalf("unexpected nil recommender")
 		}
 		if got := r.milliCPUs; got != milliCPUs {
 			t.Errorf("recommender has incorrect cpus: got %d want %d", got, milliCPUs)

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -36,7 +36,7 @@ type SettingsGroup interface {
 // recommendations for different SettingsGroups.
 type SystemConfig struct {
 	Memory         uint64
-	CPUs           int
+	MilliCPUs      int
 	PGMajorVersion string
 	WALDiskSize    uint64
 	maxConns       uint64
@@ -44,7 +44,7 @@ type SystemConfig struct {
 }
 
 // NewSystemConfig returns a new SystemConfig with the given parameters.
-func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, walDiskSize uint64, maxConns uint64, maxBGWorkers int) (*SystemConfig, error) {
+func NewSystemConfig(totalMemory uint64, milliCPUS int, pgVersion string, walDiskSize uint64, maxConns uint64, maxBGWorkers int) (*SystemConfig, error) {
 	if maxConns != 0 && maxConns < minMaxConns {
 		return nil, fmt.Errorf(errMaxConnsTooLowFmt, minMaxConns, maxConns)
 	}
@@ -53,7 +53,7 @@ func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, walDiskSize
 	}
 	return &SystemConfig{
 		Memory:         totalMemory,
-		CPUs:           cpus,
+		MilliCPUs:      milliCPUS,
 		PGMajorVersion: pgVersion,
 		WALDiskSize:    walDiskSize,
 		maxConns:       maxConns,
@@ -66,9 +66,9 @@ func NewSystemConfig(totalMemory uint64, cpus int, pgVersion string, walDiskSize
 func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 	switch {
 	case label == MemoryLabel:
-		return &MemorySettingsGroup{config.Memory, config.CPUs, config.maxConns}
+		return &MemorySettingsGroup{config.Memory, config.MilliCPUs, config.maxConns}
 	case label == ParallelLabel:
-		return &ParallelSettingsGroup{config.PGMajorVersion, config.CPUs, config.MaxBGWorkers}
+		return &ParallelSettingsGroup{config.PGMajorVersion, config.MilliCPUs, config.MaxBGWorkers}
 	case label == WALLabel:
 		return &WALSettingsGroup{config.Memory, config.WALDiskSize}
 	case label == MiscLabel:

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -50,7 +50,7 @@ func TestNewWALRecommender(t *testing.T) {
 		mem := rand.Uint64()
 		r := NewWALRecommender(mem, walDiskUnset)
 		if r == nil {
-			t.Errorf("unexpected nil recommender")
+			t.Fatalf("unexpected nil recommender")
 		}
 		if got := r.totalMemory; got != mem {
 			t.Errorf("recommender has incorrect memory: got %d want %d", got, mem)

--- a/pkg/pgutils/utils.go
+++ b/pkg/pgutils/utils.go
@@ -22,6 +22,7 @@ const (
 
 	errCouldNotParseVersionFmt = "unable to parse PG version string: %s"
 	errUnknownMajorVersionFmt  = "unknown major PG version: %s"
+	MilliScaleFactor           = 1000
 )
 
 var (

--- a/pkg/tstune/config_file_test.go
+++ b/pkg/tstune/config_file_test.go
@@ -23,7 +23,9 @@ func TestRemoveDuplicatesProcessor(t *testing.T) {
 		{content: "foo = 'quaz'"},
 	}
 	p := &removeDuplicatesProcessor{regex: keyToRegexQuoted("foo")}
-	p.Process(lines[0])
+	if err := p.Process(lines[0]); err != nil {
+		t.Errorf("Process returned error: %v", err)
+	}
 	if lines[0].remove {
 		t.Errorf("first instance incorrectly marked for remove")
 	}

--- a/pkg/tstune/print_test.go
+++ b/pkg/tstune/print_test.go
@@ -50,7 +50,7 @@ func TestColorPrinterStatement(t *testing.T) {
 	stmt := "This is a statement with %d"
 	p.Statement(stmt, 1)
 	want := whiteBoldSeq + fmt.Sprintf(stmt+"\n", 1) + resetSeq
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect statement: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -61,7 +61,7 @@ func TestColorPrinterPrompt(t *testing.T) {
 	stmt := "This is a prompt with %d"
 	p.Prompt(stmt, 1)
 	want := purpleBoldSeq + fmt.Sprintf(stmt, 1) + resetSeq
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect prompt: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -72,7 +72,7 @@ func TestColorPrinterSuccess(t *testing.T) {
 	stmt := "This is a success with %d"
 	p.Success(stmt, 1)
 	want := greenBoldSeq + successLabel + resetSeq + fmt.Sprintf(stmt+"\n", 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect success: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -84,7 +84,7 @@ func TestColorPrinterError(t *testing.T) {
 	label := "yikes"
 	p.Error(label, stmt, 1)
 	want := redBoldSeq + label + ": " + resetSeq + fmt.Sprintf(stmt+"\n", 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -95,7 +95,7 @@ func TestNoColorPrinterStatement(t *testing.T) {
 	stmt := "This is a statement with %d"
 	p.Statement(stmt, 1)
 	want := noColorPrefixStatement + fmt.Sprintf(stmt+"\n", 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect statement: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -106,7 +106,7 @@ func TestNoColorPrinterPrompt(t *testing.T) {
 	stmt := "This is a prompt with %d"
 	p.Prompt(stmt, 1)
 	want := noColorPrefixPrompt + fmt.Sprintf(stmt, 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect prompt: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -117,7 +117,7 @@ func TestNoColorPrinterSuccess(t *testing.T) {
 	stmt := "This is a success with %d"
 	p.Success(stmt, 1)
 	want := strings.ToUpper(successLabel) + fmt.Sprintf(stmt+"\n", 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect success: got\n%s\nwant\n%s", got, want)
 	}
 }
@@ -129,7 +129,7 @@ func TestNoColorPrinterError(t *testing.T) {
 	label := "yikes"
 	p.Error(label, stmt, 1)
 	want := strings.ToUpper(label) + ": " + fmt.Sprintf(stmt+"\n", 1)
-	if got := string(buf.Bytes()); got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("incorrect error: got\n%s\nwant\n%s", got, want)
 	}
 }

--- a/pkg/tstune/shared_preload_libs.go
+++ b/pkg/tstune/shared_preload_libs.go
@@ -7,7 +7,7 @@ import (
 
 const extName = "timescaledb"
 
-var sharedRegex = regexp.MustCompile("(#+?\\s*)?shared_preload_libraries = '(.*?)'.*")
+var sharedRegex = regexp.MustCompile(`(#+?\s*)?shared_preload_libraries = '(.*?)'.*`)
 
 // sharedLibResult holds the results of extracting/parsing the shared_preload_libraries
 // line of a postgresql.conf file.

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -316,7 +316,9 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 	// Add our params to the conf file, and cleanup because old versions of Tuner
 	// were noisy and left these params each time.
 	t.processOurParams()
-	t.cfs.ProcessLines(getRemoveDuplicatesProcessors(ourParams)...)
+	if err = t.cfs.ProcessLines(getRemoveDuplicatesProcessors(ourParams)...); err != nil {
+		t.handler.errorExit(fmt.Errorf("ProcessLines returned an error: %v", err))
+	}
 
 	// Wrap up: Either write it out, or show success in --dry-run
 	if !t.flags.DryRun {

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -242,7 +242,7 @@ type testRestorer struct {
 	errMsg string
 }
 
-func (r *testRestorer) Restore(backupPath, confPath string) error {
+func (r *testRestorer) Restore(_, _ string) error {
 	if r.errMsg != "" {
 		return fmt.Errorf(r.errMsg)
 	}
@@ -1295,14 +1295,18 @@ func TestTunerProcessTunables(t *testing.T) {
 	handler := setupDefaultTestIO(input)
 	cfs := &configFileState{tuneParseResults: make(map[string]*tunableParseResult)}
 	tuner := newTunerWithDefaultFlags(handler, cfs)
-	tuner.processTunables(config)
+	if err := tuner.processTunables(config); err != nil {
+		t.Errorf("processTunable returned an error: %v", err)
+	}
 	check(tuner.handler, config, 4)
 
 	config.MilliCPUs = 1 * pgutils.MilliScaleFactor
 	handler = setupDefaultTestIO(input)
 	cfs = &configFileState{tuneParseResults: make(map[string]*tunableParseResult)}
 	tuner = newTunerWithDefaultFlags(handler, cfs)
-	tuner.processTunables(config)
+	if err := tuner.processTunables(config); err != nil {
+		t.Errorf("processTunable returned an error: %v", err)
+	}
 	check(tuner.handler, config, 3)
 }
 

--- a/pkg/tstune/utils_test.go
+++ b/pkg/tstune/utils_test.go
@@ -134,7 +134,7 @@ func TestGetPGMajorVersion(t *testing.T) {
 		{
 			desc:    "failed major parse",
 			binPath: okPath60,
-			errMsg:  fmt.Sprintf("unknown major PG version: PostgreSQL 6.0.5"),
+			errMsg:  "unknown major PG version: PostgreSQL 6.0.5",
 		},
 		{
 			desc:    "failed unsupported",


### PR DESCRIPTION
Kubernetes allows configuring compute resources in fractions of a single CPU, so-called milliCPUs (e.g. 500 milliCPUs = 0.5 CPU). Use milliCPUs internally for all calculations. Support additional `--milli-cpus` parameter to specify less than 1 CPU in milliCPUs. When it is not null, it is applied instead of `--cpus.`

We don't do any special tuning for fractions of CPU, basically treating it as 1 full CPU. However, the tuning we perform based on CPU cores is either almost not affected by the difference (`work_mem`), or requires more than 1 CPU (parallel queries), so in practice it should not change any tunable parameters in a notable way.