### PR TITLE
Bump up minimum for max_connections to 25.

### DIFF
--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -32,7 +32,7 @@ const (
 	effectiveIODefaultOldVersions = "200"
 	effectiveIODefault            = "256"
 
-	minMaxConns = 20
+	minMaxConns = 25
 )
 
 // MaxConnectionsDefault is the recommended default value for max_connections.

--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -32,6 +32,9 @@ const (
 	effectiveIODefaultOldVersions = "200"
 	effectiveIODefault            = "256"
 
+	// If you want to lower this value, consider that Patroni will not accept anything less than 25 as
+	// a valid max_connections and will replace it with 100, per
+	// https://github.com/zalando/patroni/blob/00cc62726d6df25d31f9b0baa082c83cd3f7bef9/patroni/postgresql/config.py#L280
 	minMaxConns = 25
 )
 


### PR DESCRIPTION
25 is the minimum number of connections Patroni considers valid.
(per https://github.com/zalando/patroni/blob/00cc62726d6df25d31f9b0baa082c83cd3f7bef9/patroni/postgresql/config.py#L280)