### PR TITLE
Introduce the concept of profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ that you accepted from the prompts.
 
 #### Other invocations
 
+By default, timescaledb-tune provides recommendations for a typical timescaledb workload. The `--profile` flag can be
+used to tailor the recommendations for other workload types. Currently, the only non-default profile is "promscale".
+The `TSTUNE_PROFILE` environment variable can also be used to affect this behavior.
+
+```bash
+$ timescaledb-tune --profile promscale
+```
+
 If you want recommendations for a specific amount of memory and/or CPUs:
 ```bash
 $ timescaledb-tune --memory="4GB" --cpus=2

--- a/cmd/timescaledb-tune/main.go
+++ b/cmd/timescaledb-tune/main.go
@@ -45,9 +45,16 @@ func init() {
 	flag.BoolVar(&f.UseColor, "color", true, "Use color in output (works best on dark terminals)")
 	flag.BoolVar(&f.DryRun, "dry-run", false, "Whether to just show the changes without overwriting the configuration file")
 	flag.BoolVar(&f.Restore, "restore", false, "Whether to restore a previously made conf file backup")
+	flag.StringVar(&f.Profile, "profile", "", "a specific \"mode\" for tailoring recommendations to a special workload type. If blank or unspecified, a default is used unless the TSTUNE_PROFILE environment variable is set. Valid values: \"promscale\"")
 
 	flag.BoolVar(&showVersion, "version", false, "Show the version of this tool")
 	flag.Parse()
+
+	// the TSTUNE_PROFILE environment variable overrides the --profile flag if the --profile is blank or unset
+	// this is designed for docker usage
+	if val := os.Getenv("TSTUNE_PROFILE"); val != "" && f.Profile == "" {
+		f.Profile = val
+	}
 }
 
 func main() {

--- a/internal/parse/parse.md
+++ b/internal/parse/parse.md
@@ -1,0 +1,136 @@
+
+https://www.postgresql.org/docs/current/config-setting.html#20.1.1.%20Parameter%20Names%20and%20Values
+
+Postgres settings come in one of several variable types:
+
+* enum
+* string
+* bool
+* integer
+* real
+
+Some postgres settings are measured in time. They have default units, but postgres can interpret the following units if provided:
+
+* us - microseconds
+* ms - milliseconds
+* s - seconds
+* min - minutes
+* h - hours
+* d - days
+
+In postgres 14, time-based settings come in three flavors:
+
+* real milliseconds
+* integer milliseconds
+* integer seconds
+
+How postgres interprets a setting's value depends upon:
+
+1. whether the setting is a real or integer
+2. the default units
+3. whether units were specified in the input and whether those units are larger, smaller, or equal to the defaults
+4. whether the input was a fractional value
+
+statement_timeout is an integer setting with default units of milliseconds.
+
+```
+-- no units
+set statement_timeout to '155'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 155ms             │
+└───────────────────┘
+
+-- default units
+set statement_timeout to '100ms'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 100ms             │
+└───────────────────┘
+
+-- non-default units
+set statement_timeout to '100s'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 100s              │
+└───────────────────┘
+
+-- non-default units with fraction
+set statement_timeout to '100.3s'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 100300ms          │
+└───────────────────┘
+
+-- default units with fraction
+set statement_timeout to '100.7ms'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 101ms             │
+└───────────────────┘
+
+-- no units with fraction
+set statement_timeout to '155.3'; show statement_timeout;
+┌───────────────────┐
+│ statement_timeout │
+├───────────────────┤
+│ 155ms             │
+└───────────────────┘
+```
+
+vacuum_cost_delay is a real setting with default units of milliseconds.
+
+```
+-- no units
+set vacuum_cost_delay to '99'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 99ms              │
+└───────────────────┘
+
+-- default units
+set vacuum_cost_delay to '100ms'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 100ms             │
+└───────────────────┘
+
+-- non-default units
+set vacuum_cost_delay to '1000us'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 1ms               │
+└───────────────────┘
+
+-- non-default units with fraction
+set vacuum_cost_delay to '100.3us'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 100.3us           │
+└───────────────────┘
+
+-- default units with fraction
+set vacuum_cost_delay to '50.7ms'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 50700us           │
+└───────────────────┘
+
+-- no units with fraction
+set vacuum_cost_delay to '55.3'; show vacuum_cost_delay;
+┌───────────────────┐
+│ vacuum_cost_delay │
+├───────────────────┤
+│ 55300us           │
+└───────────────────┘
+```

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -268,22 +268,22 @@ func TestPGFormatToBytes(t *testing.T) {
 		{
 			desc:   "incorrect format #1",
 			input:  " 64MB", // no leading spaces
-			errMsg: fmt.Sprintf(errIncorrectFormatFmt, " 64MB"),
+			errMsg: fmt.Sprintf(errIncorrectBytesFormatFmt, " 64MB"),
 		},
 		{
 			desc:   "incorrect format #2",
 			input:  "64b", // bytes not allowed
-			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "64b"),
+			errMsg: fmt.Sprintf(errIncorrectBytesFormatFmt, "64b"),
 		},
 		{
 			desc:   "incorrect format #3",
 			input:  "64 GB", // no space between num and units,
-			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "64 GB"),
+			errMsg: fmt.Sprintf(errIncorrectBytesFormatFmt, "64 GB"),
 		},
 		{
 			desc:   "incorrect format #4",
 			input:  "-64MB", // negative memory is a no-no
-			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "-64MB"),
+			errMsg: fmt.Sprintf(errIncorrectBytesFormatFmt, "-64MB"),
 		},
 		{
 			desc:   "incorrect format #5",
@@ -293,7 +293,7 @@ func TestPGFormatToBytes(t *testing.T) {
 		{
 			desc:   "incorrect format #6",
 			input:  "5.5" + MB, // decimal memory is a no-no
-			errMsg: fmt.Sprintf(errIncorrectFormatFmt, "5.5"+MB),
+			errMsg: fmt.Sprintf(errIncorrectBytesFormatFmt, "5.5"+MB),
 		},
 		{
 			desc:  "valid bytes",
@@ -340,6 +340,11 @@ func TestPGFormatToBytes(t *testing.T) {
 			input: "2048" + TB,
 			want:  2048 * Terabyte,
 		},
+		{
+			desc:  "valid megabytes, wrapped in single-quotes",
+			input: "'64MB'",
+			want:  64 * Megabyte,
+		},
 	}
 
 	for _, c := range cases {
@@ -359,5 +364,496 @@ func TestPGFormatToBytes(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestPGFormatToTime(t *testing.T) {
+	cases := []struct {
+		desc      string
+		input     string
+		defUnits  TimeUnit
+		varType   VarType
+		wantNum   float64
+		wantUnits TimeUnit
+		errMsg    string
+	}{
+		{
+			desc:      "set statement_timeout to '13ms';",
+			input:     "13ms",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to '13ms'; #2",
+			input:     "'13ms'",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to 7;",
+			input:     "7",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   7.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to 13;",
+			input:     "13",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to 13.5;",
+			input:     "13.5",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   14.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to 13.4;",
+			input:     "13.4",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to '13.4ms';",
+			input:     "13.4ms",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to '13min';",
+			input:     "13min",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Minutes,
+		},
+		{
+			desc:      "set statement_timeout to '13.0min';",
+			input:     "13.0min",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   13.0,
+			wantUnits: Minutes,
+		},
+		{
+			desc:      "set statement_timeout to '1.5s';",
+			input:     "1.5s",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   1500.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set statement_timeout to '1.5min';",
+			input:     "1.5min",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   90.0,
+			wantUnits: Seconds,
+		},
+		{
+			desc:      "set statement_timeout to '1.3h';",
+			input:     "1.3h",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   78.0,
+			wantUnits: Minutes,
+		},
+		{
+			desc:      "set statement_timeout to '42.0 min';",
+			input:     "42.0 min",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   42.0,
+			wantUnits: Minutes,
+		},
+		{
+			desc:      "set statement_timeout to '42.1 min';",
+			input:     "42.1 min",
+			defUnits:  Milliseconds,
+			varType:   VarTypeInteger,
+			wantNum:   2526.0,
+			wantUnits: Seconds,
+		},
+		{
+			desc:     "set statement_timeout to 'bob';",
+			input:    "bob",
+			defUnits: Milliseconds,
+			varType:  VarTypeInteger,
+			errMsg:   fmt.Sprintf(errIncorrectTimeFormatFmt, "bob"),
+		},
+		{
+			desc:     "set statement_timeout to '42 bob';",
+			input:    "42 bob",
+			defUnits: Milliseconds,
+			varType:  VarTypeInteger,
+			errMsg:   fmt.Sprintf(errIncorrectTimeFormatFmt, "42 bob"),
+		},
+		{
+			desc:      "set vacuum_cost_delay to 250;",
+			input:     "250",
+			defUnits:  Milliseconds,
+			varType:   VarTypeReal,
+			wantNum:   250.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set vacuum_cost_delay to 250.0;",
+			input:     "250.0",
+			defUnits:  Milliseconds,
+			varType:   VarTypeReal,
+			wantNum:   250.0,
+			wantUnits: Milliseconds,
+		},
+		{
+			desc:      "set vacuum_cost_delay to 1.3;",
+			input:     "1.3",
+			defUnits:  Milliseconds,
+			varType:   VarTypeReal,
+			wantNum:   1300.0,
+			wantUnits: Microseconds,
+		},
+		{
+			desc:      "set vacuum_cost_delay to '1.3ms';",
+			input:     "1.3ms",
+			defUnits:  Milliseconds,
+			varType:   VarTypeReal,
+			wantNum:   1300.0,
+			wantUnits: Microseconds,
+		},
+		{
+			desc:      "set vacuum_cost_delay to '1300us';",
+			input:     "1300us",
+			defUnits:  Milliseconds,
+			varType:   VarTypeReal,
+			wantNum:   1300.0,
+			wantUnits: Microseconds,
+		},
+		{
+			desc:     "37.1 goats",
+			input:    "37.1 goats",
+			defUnits: Milliseconds,
+			varType:  VarTypeReal,
+			errMsg:   fmt.Sprintf(errIncorrectTimeFormatFmt, "37.1 goats"),
+		},
+		{
+			desc:     "37.42.1min",
+			input:    "37.42.1min",
+			defUnits: Milliseconds,
+			varType:  VarTypeReal,
+			errMsg:   fmt.Sprintf(errIncorrectTimeFormatFmt, "37.42.1min"),
+		},
+	}
+
+	for _, c := range cases {
+		v, u, err := PGFormatToTime(c.input, c.defUnits, c.varType)
+		if len(c.errMsg) > 0 { // failure cases
+			if err == nil {
+				t.Errorf("%s: unexpectedly err is nil: want %s", c.desc, c.errMsg)
+			} else if got := err.Error(); got != c.errMsg {
+				t.Errorf("%s: unexpected err msg: got\n%s\nwant\n%s", c.desc, got, c.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected err: got %v", c.desc, err)
+			}
+			if got := v; got != c.wantNum {
+				t.Errorf("%s: incorrect num: got %f want %f", c.desc, got, c.wantNum)
+			}
+			if got := u; got != c.wantUnits {
+				t.Errorf("%s: incorrect units: got %s want %s", c.desc, got, c.wantUnits)
+			}
+		}
+	}
+}
+
+func TestTimeConversion(t *testing.T) {
+	// test cases generated with the following query
+	/*
+		with x(unit, const, val) as
+		(
+		    values
+		        ('us',  'Microseconds' , interval '1 microsecond'),
+		        ('ms',  'Milliseconds' , interval '1 millisecond'),
+		        ('s',   'Seconds'      , interval '1 second'),
+		        ('min', 'Minutes'      , interval '1 minute'),
+		        ('h',   'Hours'        , interval '1 hour'),
+		        ('d',   'Days'         , interval '24 hours')
+		)
+		select string_agg(format
+		(
+		$${
+		    desc: "%s -> %s",
+		    from: %s,
+		    to:   %s,
+		    want: %s / %s,
+		}$$,
+		    f.unit,
+		    t.unit,
+		    f.const,
+		    t.const,
+		    extract(epoch from f.val),
+		    extract(epoch from t.val)
+		), E',\n' order by f.const, t.const)
+		from x f
+		cross join x t
+		;
+	*/
+
+	cases := []struct {
+		desc   string
+		from   TimeUnit
+		to     TimeUnit
+		want   float64
+		errMsg string
+	}{
+		{
+			desc: "d -> d",
+			from: Days,
+			to:   Days,
+			want: 86400.000000 / 86400.000000,
+		},
+		{
+			desc: "d -> h",
+			from: Days,
+			to:   Hours,
+			want: 86400.000000 / 3600.000000,
+		},
+		{
+			desc: "d -> us",
+			from: Days,
+			to:   Microseconds,
+			want: 86400.000000 / 0.000001,
+		},
+		{
+			desc: "d -> ms",
+			from: Days,
+			to:   Milliseconds,
+			want: 86400.000000 / 0.001000,
+		},
+		{
+			desc: "d -> min",
+			from: Days,
+			to:   Minutes,
+			want: 86400.000000 / 60.000000,
+		},
+		{
+			desc: "d -> s",
+			from: Days,
+			to:   Seconds,
+			want: 86400.000000 / 1.000000,
+		},
+		{
+			desc: "h -> d",
+			from: Hours,
+			to:   Days,
+			want: 3600.000000 / 86400.000000,
+		},
+		{
+			desc: "h -> h",
+			from: Hours,
+			to:   Hours,
+			want: 3600.000000 / 3600.000000,
+		},
+		{
+			desc: "h -> us",
+			from: Hours,
+			to:   Microseconds,
+			want: 3600.000000 / 0.000001,
+		},
+		{
+			desc: "h -> ms",
+			from: Hours,
+			to:   Milliseconds,
+			want: 3600.000000 / 0.001000,
+		},
+		{
+			desc: "h -> min",
+			from: Hours,
+			to:   Minutes,
+			want: 3600.000000 / 60.000000,
+		},
+		{
+			desc: "h -> s",
+			from: Hours,
+			to:   Seconds,
+			want: 3600.000000 / 1.000000,
+		},
+		{
+			desc: "us -> d",
+			from: Microseconds,
+			to:   Days,
+			want: 0.000001 / 86400.000000,
+		},
+		{
+			desc: "us -> h",
+			from: Microseconds,
+			to:   Hours,
+			want: 0.000001 / 3600.000000,
+		},
+		{
+			desc: "us -> us",
+			from: Microseconds,
+			to:   Microseconds,
+			want: 0.000001 / 0.000001,
+		},
+		{
+			desc: "us -> ms",
+			from: Microseconds,
+			to:   Milliseconds,
+			want: 0.000001 / 0.001000,
+		},
+		{
+			desc: "us -> min",
+			from: Microseconds,
+			to:   Minutes,
+			want: 0.000001 / 60.000000,
+		},
+		{
+			desc: "us -> s",
+			from: Microseconds,
+			to:   Seconds,
+			want: 0.000001 / 1.000000,
+		},
+		{
+			desc: "ms -> d",
+			from: Milliseconds,
+			to:   Days,
+			want: 0.001000 / 86400.000000,
+		},
+		{
+			desc: "ms -> h",
+			from: Milliseconds,
+			to:   Hours,
+			want: 0.001000 / 3600.000000,
+		},
+		{
+			desc: "ms -> us",
+			from: Milliseconds,
+			to:   Microseconds,
+			want: 0.001000 / 0.000001,
+		},
+		{
+			desc: "ms -> ms",
+			from: Milliseconds,
+			to:   Milliseconds,
+			want: 0.001000 / 0.001000,
+		},
+		{
+			desc: "ms -> min",
+			from: Milliseconds,
+			to:   Minutes,
+			want: 0.001000 / 60.000000,
+		},
+		{
+			desc: "ms -> s",
+			from: Milliseconds,
+			to:   Seconds,
+			want: 0.001000 / 1.000000,
+		},
+		{
+			desc: "min -> d",
+			from: Minutes,
+			to:   Days,
+			want: 60.000000 / 86400.000000,
+		},
+		{
+			desc: "min -> h",
+			from: Minutes,
+			to:   Hours,
+			want: 60.000000 / 3600.000000,
+		},
+		{
+			desc: "min -> us",
+			from: Minutes,
+			to:   Microseconds,
+			want: 60.000000 / 0.000001,
+		},
+		{
+			desc: "min -> ms",
+			from: Minutes,
+			to:   Milliseconds,
+			want: 60.000000 / 0.001000,
+		},
+		{
+			desc: "min -> min",
+			from: Minutes,
+			to:   Minutes,
+			want: 60.000000 / 60.000000,
+		},
+		{
+			desc: "min -> s",
+			from: Minutes,
+			to:   Seconds,
+			want: 60.000000 / 1.000000,
+		},
+		{
+			desc: "s -> d",
+			from: Seconds,
+			to:   Days,
+			want: 1.000000 / 86400.000000,
+		},
+		{
+			desc: "s -> h",
+			from: Seconds,
+			to:   Hours,
+			want: 1.000000 / 3600.000000,
+		},
+		{
+			desc: "s -> us",
+			from: Seconds,
+			to:   Microseconds,
+			want: 1.000000 / 0.000001,
+		},
+		{
+			desc: "s -> ms",
+			from: Seconds,
+			to:   Milliseconds,
+			want: 1.000000 / 0.001000,
+		},
+		{
+			desc: "s -> min",
+			from: Seconds,
+			to:   Minutes,
+			want: 1.000000 / 60.000000,
+		},
+		{
+			desc: "s -> s",
+			from: Seconds,
+			to:   Seconds,
+			want: 1.000000 / 1.000000,
+		},
+	}
+
+	for _, c := range cases {
+		conv, err := TimeConversion(c.from, c.to)
+		if c.errMsg != "" {
+			if err != nil {
+				t.Errorf("%s: unexpectedly err is nil: want %s", c.desc, c.errMsg)
+			} else if got := err.Error(); got != c.errMsg {
+				t.Errorf("%s: unexpected err msg: got\n%s\nwant\n%s", c.desc, got, c.errMsg)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected err: got %v", c.desc, err)
+			}
+			if got := conv; got != c.want {
+				t.Errorf("%s: incorrect conv: got %f want %f", c.desc, got, c.want)
+			}
+		}
 	}
 }

--- a/pkg/pgtune/background_writer.go
+++ b/pkg/pgtune/background_writer.go
@@ -1,0 +1,83 @@
+package pgtune
+
+import "github.com/timescale/timescaledb-tune/internal/parse"
+
+const (
+	BgwriterDelayKey       = "bgwriter_delay"
+	BgwriterLRUMaxPagesKey = "bgwriter_lru_maxpages"
+
+	promscaleDefaultBgwriterDelay       = "10ms"
+	promscaleDefaultBgwriterLRUMaxPages = "100000"
+)
+
+// BgwriterLabel is the label used to refer to the background writer settings group
+const BgwriterLabel = "background writer"
+
+var BgwriterKeys = []string{
+	BgwriterDelayKey,
+	BgwriterLRUMaxPagesKey,
+}
+
+// PromscaleBgwriterRecommender gives recommendations for the background writer for the promscale profile
+type PromscaleBgwriterRecommender struct{}
+
+// IsAvailable returns whether this Recommender is usable given the system resources. Always true.
+func (r *PromscaleBgwriterRecommender) IsAvailable() bool {
+	return true
+}
+
+// Recommend returns the recommended PostgreSQL formatted value for the conf
+// file for a given key.
+func (r *PromscaleBgwriterRecommender) Recommend(key string) string {
+	switch key {
+	case BgwriterDelayKey:
+		return promscaleDefaultBgwriterDelay
+	case BgwriterLRUMaxPagesKey:
+		return promscaleDefaultBgwriterLRUMaxPages
+	default:
+		return NoRecommendation
+	}
+}
+
+// BgwriterSettingsGroup is the SettingsGroup to represent settings that affect the background writer.
+type BgwriterSettingsGroup struct {
+	totalMemory uint64
+	cpus        int
+	maxConns    uint64
+}
+
+// Label should always return the value BgwriterLabel.
+func (sg *BgwriterSettingsGroup) Label() string { return BgwriterLabel }
+
+// Keys should always return the BgwriterKeys slice.
+func (sg *BgwriterSettingsGroup) Keys() []string { return BgwriterKeys }
+
+// GetRecommender should return a new Recommender.
+func (sg *BgwriterSettingsGroup) GetRecommender(profile Profile) Recommender {
+	switch profile {
+	case PromscaleProfile:
+		return &PromscaleBgwriterRecommender{}
+	default:
+		return &NullRecommender{}
+	}
+}
+
+type BgwriterFloatParser struct{}
+
+func (v *BgwriterFloatParser) ParseFloat(key string, s string) (float64, error) {
+	switch key {
+	case BgwriterDelayKey:
+		val, units, err := parse.PGFormatToTime(s, parse.Milliseconds, parse.VarTypeInteger)
+		if err != nil {
+			return val, err
+		}
+		conv, err := parse.TimeConversion(units, parse.Milliseconds)
+		if err != nil {
+			return val, err
+		}
+		return val * conv, nil
+	default:
+		bfp := &numericFloatParser{}
+		return bfp.ParseFloat(key, s)
+	}
+}

--- a/pkg/pgtune/background_writer_test.go
+++ b/pkg/pgtune/background_writer_test.go
@@ -1,0 +1,87 @@
+package pgtune
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/timescale/timescaledb-tune/internal/parse"
+)
+
+func TestBgwriterSettingsGroup_GetRecommender(t *testing.T) {
+	cases := []struct {
+		profile     Profile
+		recommender string
+	}{
+		{DefaultProfile, "*pgtune.NullRecommender"},
+		{PromscaleProfile, "*pgtune.PromscaleBgwriterRecommender"},
+	}
+
+	sg := BgwriterSettingsGroup{}
+	for _, k := range cases {
+		r := sg.GetRecommender(k.profile)
+		y := fmt.Sprintf("%T", r)
+		if y != k.recommender {
+			t.Errorf("Expected to get a %s using the %s profile but got %s", k.recommender, k.profile, y)
+		}
+	}
+}
+
+func TestBgwriterSettingsGroupRecommend(t *testing.T) {
+	sg := BgwriterSettingsGroup{}
+
+	// the default profile should provide no recommendations
+	r := sg.GetRecommender(DefaultProfile)
+	if val := r.Recommend(BgwriterDelayKey); val != NoRecommendation {
+		t.Errorf("Expected no recommendation for key %s but got %s", BgwriterDelayKey, val)
+	}
+	if val := r.Recommend(BgwriterLRUMaxPagesKey); val != NoRecommendation {
+		t.Errorf("Expected no recommendation for key %s but got %s", BgwriterLRUMaxPagesKey, val)
+	}
+
+	// the promscale profile should have recommendations
+	r = sg.GetRecommender(PromscaleProfile)
+	if val := r.Recommend(BgwriterDelayKey); val != promscaleDefaultBgwriterDelay {
+		t.Errorf("Expected %s for key %s but got %s", promscaleDefaultBgwriterDelay, BgwriterDelayKey, val)
+	}
+	if val := r.Recommend(BgwriterLRUMaxPagesKey); val != promscaleDefaultBgwriterLRUMaxPages {
+		t.Errorf("Expected %s for key %s but got %s", promscaleDefaultBgwriterLRUMaxPages, BgwriterLRUMaxPagesKey, val)
+	}
+}
+
+func TestPromscaleBgwriterRecommender(t *testing.T) {
+	r := PromscaleBgwriterRecommender{}
+	if !r.IsAvailable() {
+		t.Error("PromscaleBgwriterRecommender should always be available")
+	}
+	if val := r.Recommend(BgwriterDelayKey); val != promscaleDefaultBgwriterDelay {
+		t.Errorf("Expected %s for key %s but got %s", promscaleDefaultBgwriterDelay, BgwriterDelayKey, val)
+	}
+	if val := r.Recommend(BgwriterLRUMaxPagesKey); val != promscaleDefaultBgwriterLRUMaxPages {
+		t.Errorf("Expected %s for key %s but got %s", promscaleDefaultBgwriterLRUMaxPages, BgwriterLRUMaxPagesKey, val)
+	}
+}
+
+func TestBgwriterFloatParserParseFloat(t *testing.T) {
+	v := &BgwriterFloatParser{}
+
+	s := "100"
+	want := 100.0
+	got, err := v.ParseFloat(BgwriterLRUMaxPagesKey, s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+
+	s = "33" + parse.Minutes.String()
+	conversion, _ := parse.TimeConversion(parse.Minutes, parse.Milliseconds)
+	want = 33.0 * conversion
+	got, err = v.ParseFloat(BgwriterDelayKey, s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+}

--- a/pkg/pgtune/float_parser.go
+++ b/pkg/pgtune/float_parser.go
@@ -1,0 +1,42 @@
+package pgtune
+
+import (
+	"strconv"
+
+	"github.com/timescale/timescaledb-tune/internal/parse"
+)
+
+type FloatParser interface {
+	ParseFloat(string, string) (float64, error)
+}
+
+type bytesFloatParser struct{}
+
+func (v *bytesFloatParser) ParseFloat(key string, s string) (float64, error) {
+	temp, err := parse.PGFormatToBytes(s)
+	return float64(temp), err
+}
+
+type numericFloatParser struct{}
+
+func (v *numericFloatParser) ParseFloat(key string, s string) (float64, error) {
+	return strconv.ParseFloat(s, 64)
+}
+
+// GetFloatParser returns the correct FloatParser for a given Recommender.
+func GetFloatParser(r Recommender) FloatParser {
+	switch r.(type) {
+	case *MemoryRecommender:
+		return &bytesFloatParser{}
+	case *WALRecommender:
+		return &WALFloatParser{}
+	case *PromscaleWALRecommender:
+		return &WALFloatParser{}
+	case *PromscaleBgwriterRecommender:
+		return &BgwriterFloatParser{}
+	case *ParallelRecommender:
+		return &numericFloatParser{}
+	default:
+		return &numericFloatParser{}
+	}
+}

--- a/pkg/pgtune/float_parser_test.go
+++ b/pkg/pgtune/float_parser_test.go
@@ -1,0 +1,77 @@
+package pgtune
+
+import (
+	"testing"
+
+	"github.com/timescale/timescaledb-tune/internal/parse"
+)
+
+func TestBytesFloatParserParseFloat(t *testing.T) {
+	s := "8" + parse.GB
+	want := float64(8 * parse.Gigabyte)
+	v := &bytesFloatParser{}
+	got, err := v.ParseFloat("foo", s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+}
+
+func TestNumericFloatParserParseFloat(t *testing.T) {
+	s := "8.245"
+	want := 8.245
+	v := &numericFloatParser{}
+	got, err := v.ParseFloat("foo", s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+}
+
+func TestGetFloatParser(t *testing.T) {
+	switch x := (GetFloatParser(&MemoryRecommender{})).(type) {
+	case *bytesFloatParser:
+	default:
+		t.Errorf("wrong validator type for MemoryRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&WALRecommender{})).(type) {
+	case *WALFloatParser:
+	default:
+		t.Errorf("wrong validator type for WALRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&PromscaleWALRecommender{})).(type) {
+	case *WALFloatParser:
+	default:
+		t.Errorf("wrong validator type for PromscaleWALRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&ParallelRecommender{})).(type) {
+	case *numericFloatParser:
+	default:
+		t.Errorf("wrong validator type for ParallelRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&PromscaleBgwriterRecommender{})).(type) {
+	case *BgwriterFloatParser:
+	default:
+		t.Errorf("wrong validator type for PromscaleBgwriterRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&MiscRecommender{})).(type) {
+	case *numericFloatParser:
+	default:
+		t.Errorf("wrong validator type for MiscRecommender: got %T", x)
+	}
+
+	switch x := (GetFloatParser(&NullRecommender{})).(type) {
+	case *numericFloatParser:
+	default:
+		t.Errorf("wrong validator type for NullRecommender: got %T", x)
+	}
+}

--- a/pkg/pgtune/memory.go
+++ b/pkg/pgtune/memory.go
@@ -1,7 +1,6 @@
 package pgtune
 
 import (
-	"fmt"
 	"math"
 	"runtime"
 
@@ -89,7 +88,7 @@ func (r *MemoryRecommender) Recommend(key string) string {
 		}
 
 	} else {
-		panic(fmt.Sprintf("unknown key: %s", key))
+		val = NoRecommendation
 	}
 	return val
 }
@@ -126,6 +125,6 @@ func (sg *MemorySettingsGroup) Label() string { return MemoryLabel }
 func (sg *MemorySettingsGroup) Keys() []string { return MemoryKeys }
 
 // GetRecommender should return a new MemoryRecommender.
-func (sg *MemorySettingsGroup) GetRecommender() Recommender {
+func (sg *MemorySettingsGroup) GetRecommender(profile Profile) Recommender {
 	return NewMemoryRecommender(sg.totalMemory, sg.cpus, sg.maxConns)
 }

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -214,16 +214,11 @@ func TestMemoryRecommenderRecommend(t *testing.T) {
 	}
 }
 
-func TestMemoryRecommenderRecommendPanic(t *testing.T) {
-	func() {
-		r := NewMemoryRecommender(1, 1, 1)
-		defer func() {
-			if re := recover(); re == nil {
-				t.Errorf("did not panic when should")
-			}
-		}()
-		r.Recommend("foo")
-	}()
+func TestMemoryRecommenderNoRecommendation(t *testing.T) {
+	r := NewMemoryRecommender(1, 1, 1)
+	if r.Recommend("foo") != NoRecommendation {
+		t.Error("Recommendation was provided when there should have been none")
+	}
 }
 
 func TestMemorySettingsGroup(t *testing.T) {
@@ -236,7 +231,7 @@ func TestMemorySettingsGroup(t *testing.T) {
 				config.maxConns = conns
 
 				sg := GetSettingsGroup(MemoryLabel, config)
-				testSettingGroup(t, sg, matrix, MemoryLabel, MemoryKeys)
+				testSettingGroup(t, sg, DefaultProfile, matrix, MemoryLabel, MemoryKeys)
 			}
 		}
 	}

--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -141,7 +141,7 @@ func (r *MiscRecommender) Recommend(key string) string {
 	} else if key == EffectiveIOKey {
 		val = getEffectiveIOConcurrency(r.pgMajorVersion)
 	} else {
-		panic(fmt.Sprintf("unknown key: %s", key))
+		val = NoRecommendation
 	}
 	return val
 }
@@ -165,6 +165,6 @@ func (sg *MiscSettingsGroup) Keys() []string {
 }
 
 // GetRecommender should return a new MiscRecommender.
-func (sg *MiscSettingsGroup) GetRecommender() Recommender {
+func (sg *MiscSettingsGroup) GetRecommender(profile Profile) Recommender {
 	return NewMiscRecommender(sg.totalMemory, sg.maxConns, sg.pgMajorVersion)
 }

--- a/pkg/pgtune/misc_test.go
+++ b/pkg/pgtune/misc_test.go
@@ -179,16 +179,11 @@ func TestMiscRecommenderRecommend(t *testing.T) {
 	}
 }
 
-func TestMiscRecommenderRecommendPanic(t *testing.T) {
-	func() {
-		r := &MiscRecommender{}
-		defer func() {
-			if re := recover(); re == nil {
-				t.Errorf("did not panic when should")
-			}
-		}()
-		r.Recommend("foo")
-	}()
+func TestMiscRecommenderNoRecommendation(t *testing.T) {
+	r := &MiscRecommender{}
+	if r.Recommend("foo") != NoRecommendation {
+		t.Error("Recommendation was provided when there should have been none")
+	}
 }
 
 func TestMiscSettingsGroup(t *testing.T) {
@@ -200,7 +195,7 @@ func TestMiscSettingsGroup(t *testing.T) {
 			}
 			sg := GetSettingsGroup(MiscLabel, config)
 
-			testSettingGroup(t, sg, matrix, MiscLabel, MiscKeys)
+			testSettingGroup(t, sg, DefaultProfile, matrix, MiscLabel, MiscKeys)
 		}
 	}
 }

--- a/pkg/pgtune/null_recommender.go
+++ b/pkg/pgtune/null_recommender.go
@@ -1,0 +1,16 @@
+package pgtune
+
+// NullRecommender is a Recommender that returns NoRecommendation for all keys
+type NullRecommender struct {
+}
+
+// IsAvailable returns whether this Recommender is usable given the system resources. Always true.
+func (r *NullRecommender) IsAvailable() bool {
+	return true
+}
+
+// Recommend returns the recommended PostgreSQL formatted value for the conf
+// file for a given key.
+func (r *NullRecommender) Recommend(key string) string {
+	return NoRecommendation
+}

--- a/pkg/pgtune/null_recommender_test.go
+++ b/pkg/pgtune/null_recommender_test.go
@@ -1,0 +1,17 @@
+package pgtune
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNullRecommender_Recommend(t *testing.T) {
+	r := &NullRecommender{}
+	// NullRecommender should ALWAYS return NoRecommendation
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprintf("key%d", i)
+		if val := r.Recommend(key); val != NoRecommendation {
+			t.Errorf("Expected no recommendation for key %s but got %s", key, val)
+		}
+	}
+}

--- a/pkg/pgtune/parallel.go
+++ b/pkg/pgtune/parallel.go
@@ -69,7 +69,7 @@ func (r *ParallelRecommender) Recommend(key string) string {
 	} else if key == MaxBackgroundWorkers {
 		val = fmt.Sprintf("%d", r.maxBGWorkers)
 	} else {
-		panic(fmt.Sprintf("unknown key: %s", key))
+		val = NoRecommendation
 	}
 	return val
 }
@@ -93,6 +93,6 @@ func (sg *ParallelSettingsGroup) Keys() []string {
 }
 
 // GetRecommender should return a new ParallelRecommender.
-func (sg *ParallelSettingsGroup) GetRecommender() Recommender {
+func (sg *ParallelSettingsGroup) GetRecommender(profile Profile) Recommender {
 	return NewParallelRecommender(sg.cpus, sg.maxBGWorkers)
 }

--- a/pkg/pgtune/parallel_test.go
+++ b/pkg/pgtune/parallel_test.go
@@ -99,18 +99,14 @@ func TestParallelRecommenderRecommend(t *testing.T) {
 	}
 }
 
-func TestParallelRecommenderRecommendPanics(t *testing.T) {
-	// test invalid key panic
-	func() {
-		r := &ParallelRecommender{5, MaxBackgroundWorkersDefault}
-		defer func() {
-			if re := recover(); re == nil {
-				t.Errorf("did not panic when should")
-			}
-		}()
-		r.Recommend("foo")
-	}()
+func TestParallelRecommenderNoRecommendation(t *testing.T) {
+	r := &ParallelRecommender{5, MaxBackgroundWorkersDefault}
+	if r.Recommend("foo") != NoRecommendation {
+		t.Error("Recommendation was provided when there should have been none")
+	}
+}
 
+func TestParallelRecommenderRecommendPanics(t *testing.T) {
 	// test invalid CPU panic
 	func() {
 		defer func() {
@@ -146,7 +142,7 @@ func TestParallelSettingsGroup(t *testing.T) {
 			if got := len(sg.Keys()); got != keyCount-1 {
 				t.Errorf("incorrect number of keys for PG %s: got %d want %d", pgutils.MajorVersion96, got, keyCount-1)
 			}
-			testSettingGroup(t, sg, matrix, ParallelLabel, ParallelKeys)
+			testSettingGroup(t, sg, DefaultProfile, matrix, ParallelLabel, ParallelKeys)
 
 			// PG10 adds a key
 			config.PGMajorVersion = pgutils.MajorVersion10
@@ -154,14 +150,14 @@ func TestParallelSettingsGroup(t *testing.T) {
 			if got := len(sg.Keys()); got != keyCount {
 				t.Errorf("incorrect number of keys for PG %s: got %d want %d", pgutils.MajorVersion10, got, keyCount)
 			}
-			testSettingGroup(t, sg, matrix, ParallelLabel, ParallelKeys)
+			testSettingGroup(t, sg, DefaultProfile, matrix, ParallelLabel, ParallelKeys)
 
 			config.PGMajorVersion = pgutils.MajorVersion11
 			sg = GetSettingsGroup(ParallelLabel, config)
 			if got := len(sg.Keys()); got != keyCount {
 				t.Errorf("incorrect number of keys for PG %s: got %d want %d", pgutils.MajorVersion11, got, keyCount)
 			}
-			testSettingGroup(t, sg, matrix, ParallelLabel, ParallelKeys)
+			testSettingGroup(t, sg, DefaultProfile, matrix, ParallelLabel, ParallelKeys)
 		}
 	}
 

--- a/pkg/pgtune/wal_test.go
+++ b/pkg/pgtune/wal_test.go
@@ -1,6 +1,7 @@
 package pgtune
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -29,9 +30,19 @@ var walDiskToMaxBytes = map[uint64]uint64{
 	walDiskDivideEvenly:   5280 * parse.Megabyte,
 }
 
+var promscaleWALDiskToMaxBytes = map[uint64]uint64{
+	walDiskUnset:          promscaleDefaultMaxWALBytes,
+	walDiskDivideUnevenly: 4928 * parse.Megabyte, // nearest 16MB segment
+	walDiskDivideEvenly:   5280 * parse.Megabyte,
+}
+
 // walSettingsMatrix stores the test cases for WALRecommender along with the
 // expected values for WAL keys.
 var walSettingsMatrix = map[uint64]map[uint64]map[string]string{}
+
+// walSettingsMatrix stores the test cases for WALRecommender along with the
+// expected values for WAL keys.
+var promscaleWalSettingsMatrix = map[uint64]map[uint64]map[string]string{}
 
 func init() {
 	for memory, walBuffers := range memoryToWALBuffers {
@@ -41,6 +52,37 @@ func init() {
 			walSettingsMatrix[memory][walSize][MinWALKey] = parse.BytesToPGFormat(walDiskToMaxBytes[walSize] / 2)
 			walSettingsMatrix[memory][walSize][MaxWALKey] = parse.BytesToPGFormat(walDiskToMaxBytes[walSize])
 			walSettingsMatrix[memory][walSize][WALBuffersKey] = parse.BytesToPGFormat(walBuffers)
+			walSettingsMatrix[memory][walSize][CheckpointTimeoutKey] = NoRecommendation
+		}
+	}
+
+	for memory, walBuffers := range memoryToWALBuffers {
+		promscaleWalSettingsMatrix[memory] = make(map[uint64]map[string]string)
+		for walSize := range walDiskToMaxBytes {
+			promscaleWalSettingsMatrix[memory][walSize] = make(map[string]string)
+			promscaleWalSettingsMatrix[memory][walSize][MinWALKey] = parse.BytesToPGFormat(promscaleWALDiskToMaxBytes[walSize] / 2)
+			promscaleWalSettingsMatrix[memory][walSize][MaxWALKey] = parse.BytesToPGFormat(promscaleWALDiskToMaxBytes[walSize])
+			promscaleWalSettingsMatrix[memory][walSize][WALBuffersKey] = parse.BytesToPGFormat(walBuffers)
+			promscaleWalSettingsMatrix[memory][walSize][CheckpointTimeoutKey] = promscaleDefaultCheckpointTimeout
+		}
+	}
+}
+
+func TestWALSettingsGroup_GetRecommender(t *testing.T) {
+	cases := []struct {
+		profile     Profile
+		recommender string
+	}{
+		{DefaultProfile, "*pgtune.WALRecommender"},
+		{PromscaleProfile, "*pgtune.PromscaleWALRecommender"},
+	}
+
+	sg := WALSettingsGroup{totalMemory: 1, walDiskSize: 1}
+	for _, k := range cases {
+		r := sg.GetRecommender(k.profile)
+		y := fmt.Sprintf("%T", r)
+		if y != k.recommender {
+			t.Errorf("Expected to get a %s using the %s profile but got %s", k.recommender, k.profile, y)
 		}
 	}
 }
@@ -71,16 +113,34 @@ func TestWALRecommenderRecommend(t *testing.T) {
 	}
 }
 
-func TestWALRecommenderRecommendPanic(t *testing.T) {
-	func() {
-		r := NewWALRecommender(0, 0)
-		defer func() {
-			if re := recover(); re == nil {
-				t.Errorf("did not panic when should")
-			}
-		}()
-		r.Recommend("foo")
-	}()
+func TestPromscaleWALRecommenderRecommend(t *testing.T) {
+	for totalMemory, outerMatrix := range promscaleWalSettingsMatrix {
+		for walSize, matrix := range outerMatrix {
+			r := NewPromscaleWALRecommender(totalMemory, walSize)
+			testRecommender(t, r, WALKeys, matrix)
+		}
+	}
+}
+
+func TestPromscaleWALRecommenderCheckpointTimeout(t *testing.T) {
+	// recommendation for checkpoint timeout should not be impacted by totalMemory or walDiskSize
+	for i := uint64(0); i < 1000000; i++ {
+		r := NewPromscaleWALRecommender(i, i)
+		if v := r.Recommend(CheckpointTimeoutKey); v != promscaleDefaultCheckpointTimeout {
+			t.Errorf("Expected %s for %s, but got %s", promscaleDefaultCheckpointTimeout, CheckpointTimeoutKey, v)
+		}
+	}
+}
+
+func TestWALRecommenderNoRecommendation(t *testing.T) {
+	r := NewWALRecommender(0, 0)
+	if r.Recommend("foo") != NoRecommendation {
+		t.Errorf("Recommendation was provided for %s when there should have been none", "foo")
+	}
+
+	if r.Recommend(CheckpointTimeoutKey) != NoRecommendation {
+		t.Errorf("Recommendation was provided for %s when there should have been none", CheckpointTimeoutKey)
+	}
 }
 
 func TestWALSettingsGroup(t *testing.T) {
@@ -90,7 +150,52 @@ func TestWALSettingsGroup(t *testing.T) {
 			config.Memory = totalMemory
 			config.WALDiskSize = walSize
 			sg := GetSettingsGroup(WALLabel, config)
-			testSettingGroup(t, sg, matrix, WALLabel, WALKeys)
+			testSettingGroup(t, sg, DefaultProfile, matrix, WALLabel, WALKeys)
 		}
+	}
+
+	for totalMemory, outerMatrix := range promscaleWalSettingsMatrix {
+		for walSize, matrix := range outerMatrix {
+			config := getDefaultTestSystemConfig(t)
+			config.Memory = totalMemory
+			config.WALDiskSize = walSize
+			sg := GetSettingsGroup(WALLabel, config)
+			testSettingGroup(t, sg, PromscaleProfile, matrix, WALLabel, WALKeys)
+		}
+	}
+}
+
+func TestWALFloatParserParseFloat(t *testing.T) {
+	v := &WALFloatParser{}
+
+	s := "8" + parse.GB
+	want := float64(8 * parse.Gigabyte)
+	got, err := v.ParseFloat(MaxWALKey, s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+
+	s = "1000"
+	want = 1000.0
+	got, err = v.ParseFloat(WALBuffersKey, s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
+	}
+
+	s = "33" + parse.Minutes.String()
+	conversion, _ := parse.TimeConversion(parse.Minutes, parse.Milliseconds)
+	want = 33.0 * conversion
+	got, err = v.ParseFloat(CheckpointTimeoutKey, s)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("incorrect result: got %f want %f", got, want)
 	}
 }

--- a/pkg/tstune/tune_settings.go
+++ b/pkg/tstune/tune_settings.go
@@ -3,10 +3,8 @@ package tstune
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"time"
 
-	"github.com/timescale/timescaledb-tune/internal/parse"
 	"github.com/timescale/timescaledb-tune/pkg/pgtune"
 )
 
@@ -59,35 +57,7 @@ func init() {
 	setup(pgtune.ParallelKeys)
 	setup(pgtune.WALKeys)
 	setup(pgtune.MiscKeys)
-}
-
-type floatParser interface {
-	ParseFloat(string) (float64, error)
-}
-
-type bytesFloatParser struct{}
-
-func (v *bytesFloatParser) ParseFloat(s string) (float64, error) {
-	temp, err := parse.PGFormatToBytes(s)
-	return float64(temp), err
-}
-
-type numericFloatParser struct{}
-
-func (v *numericFloatParser) ParseFloat(s string) (float64, error) {
-	return strconv.ParseFloat(s, 64)
-}
-
-// getFloatParser returns the correct floatParser for a given pgtune.Recommender.
-func getFloatParser(r pgtune.Recommender) floatParser {
-	switch r.(type) {
-	case *pgtune.MemoryRecommender:
-		return &bytesFloatParser{}
-	case *pgtune.WALRecommender:
-		return &bytesFloatParser{}
-	default:
-		return &numericFloatParser{}
-	}
+	setup(pgtune.BgwriterKeys)
 }
 
 // keyToRegex takes a conf file key/param name and creates the correct regular

--- a/pkg/tstune/tune_settings_test.go
+++ b/pkg/tstune/tune_settings_test.go
@@ -5,9 +5,6 @@ import (
 	"regexp"
 	"testing"
 	"time"
-
-	"github.com/timescale/timescaledb-tune/internal/parse"
-	"github.com/timescale/timescaledb-tune/pkg/pgtune"
 )
 
 // To make the test less flaky, we 0 out the seconds to make the comparison
@@ -40,58 +37,6 @@ func TestOurParamToValue(t *testing.T) {
 		}
 	}()
 	_ = ourParamString("not_a_real_param")
-}
-
-func TestBytesFloatParserParseFloat(t *testing.T) {
-	s := "8" + parse.GB
-	want := float64(8 * parse.Gigabyte)
-	v := &bytesFloatParser{}
-	got, err := v.ParseFloat(s)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if got != want {
-		t.Errorf("incorrect result: got %f want %f", got, want)
-	}
-}
-
-func TestNumericFloatParserParseFloat(t *testing.T) {
-	s := "8.245"
-	want := 8.245
-	v := &numericFloatParser{}
-	got, err := v.ParseFloat(s)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if got != want {
-		t.Errorf("incorrect result: got %f want %f", got, want)
-	}
-}
-
-func TestGetFloatParser(t *testing.T) {
-	switch x := (getFloatParser(&pgtune.MemoryRecommender{})).(type) {
-	case *bytesFloatParser:
-	default:
-		t.Errorf("wrong validator type for MemoryRecommender: got %T", x)
-	}
-
-	switch x := (getFloatParser(&pgtune.WALRecommender{})).(type) {
-	case *bytesFloatParser:
-	default:
-		t.Errorf("wrong validator type for WALRecommender: got %T", x)
-	}
-
-	switch x := (getFloatParser(&pgtune.ParallelRecommender{})).(type) {
-	case *numericFloatParser:
-	default:
-		t.Errorf("wrong validator type for ParallelRecommender: got %T", x)
-	}
-
-	switch x := (getFloatParser(&pgtune.MiscRecommender{})).(type) {
-	case *numericFloatParser:
-	default:
-		t.Errorf("wrong validator type for MiscRecommender: got %T", x)
-	}
 }
 
 const (


### PR DESCRIPTION
A profile is an optional "mode" to put the tuner in that tailors the recommendations for a particular workload.
If no profile is specified, the tuner is run with a default profile which provides exactly the same behavior as
before and corresponds to the typical timescaledb workload.

The only other valid profile defined at the moment is "promscale".

The profile is specified using either the `--profile` argument or the `TSTUNE_PROFILE` environment variable. The environment variable overrides the command line argument if both are specified. In this way, the environment variable can be passed to `docker run`, and we therefore do not need different docker images per profile.


The promscale profile needs to make recommendations for a couple of postgres settings that are measured in units of time. This PR adds functionality to timescaledb-tune to be able to interpret and handle settings measured in time. This was not as straightforward as was hoped because how postgres interprets a setting's value depends upon:

1. whether the setting is a real or integer
2. the default units
3. whether units were specified in the input and whether those units are larger, smaller, or equal to the defaults
4. whether the input was a fractional value

With the addition of profiles, it is possible for one profile to provide recommendations for settings which a different profile simply ignores. This PR had to provide a way for a Recommender to signal that it was providing "no recommendation" for a given setting.

A SettingsGroup now returns an appropriate Recommender based upon the selected profile. A NullRecommender can be provided in the case that no recommendations are provided for the selected profile and SettingsGroup. A NullRecommender provides no recommendation for all settings passed to it.

SettingsGroups can now have a mixture of settings that are measured in time, bytes, or unit-less. The FloatParser implementations and logic had to change to accommodate this. 