### PR TITLE
Don't require exactly one space before or after =

### DIFF
--- a/pkg/tstune/tune_settings.go
+++ b/pkg/tstune/tune_settings.go
@@ -40,10 +40,10 @@ const (
 	// conf file that just needs to be Sprintf'd with the key name. That is, its
 	// usage is usually:
 	// regex := fmt.Sprintf(tuneRegexFmt, "key_name")
-	tuneRegexFmt = "^(\\s*#+?\\s*)?(%s) = (\\S+?)(\\s*(?:#.*|))$"
+	tuneRegexFmt = `^(\s*#+?\s*)?(%s)\s*=\s*(\S+?)(\s*(?:#.*|))$`
 	// tuneRegexQuotedFmt is similar to the format above but for string parameters
 	// that need single quotes around them
-	tuneRegexQuotedFmt = "^(\\s*#+?\\s*)?(%s) = '(.+?)'(\\s*(?:#.*|))$"
+	tuneRegexQuotedFmt = `^(\s*#+?\s*)?(%s)\s*=\s*'(.+?)'(\s*(?:#.*|))$`
 )
 
 var regexes = make(map[string]*regexp.Regexp)

--- a/pkg/tstune/tune_settings_test.go
+++ b/pkg/tstune/tune_settings_test.go
@@ -147,6 +147,27 @@ func TestParseWithRegex(t *testing.T) {
 			},
 		},
 		{
+			desc:  "correct, no whitespace surrounding =",
+			input: testKey + "=50.0",
+			want: &tunableParseResult{
+				commented: false,
+				key:       testKey,
+				value:     "50.0",
+				extra:     "",
+			},
+		},
+		{
+			desc:  "correct, much whitespace surrounding =",
+			input: testKey + "    =      50.0",
+			want: &tunableParseResult{
+				commented: false,
+				key:       testKey,
+				value:     "50.0",
+				extra:     "",
+			},
+		},
+
+		{
 			desc:  "correct, comment at end",
 			input: testKey + " = 50.0 # do not change!",
 			want: &tunableParseResult{


### PR DESCRIPTION
My postgresql.conf looks like this:

	checkpoint_timeout = 30min   # Max. time between checkpoints; Default: 5min
	max_wal_size       = 4GB     # Default: 1G
	min_wal_size       = 256MB   # Default: 80M

It would fail to detect these keys as the tuneRegexFmt and
tuneRegexQuotedFmt require exactly " = "; this changes that to "\s*=\s*"
to accept any whitespace. It doesn't make any effort to write these
spaces back – might be nice too, but I couldn't be bothered 😅

Also use ` for these strings so you don't need to double up the
backslashes.