### PR TITLE
Jobs waiting-for-engineering, waiting-for-author

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,16 +1,62 @@
 name: Add bugs to bugs project
 
-on:
+"on":
   issues:
-    types: [ opened, labeled ]
+    types: [opened, labeled]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.1.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/timescale/projects/55
           github-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           labeled: bug
+
+  waiting-for-author:
+    name: Waiting for Author
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && github.event.action == 'labeled'
+      && github.event.label.name == 'waiting-for-author'
+    steps:
+      - uses: leonsteinhaeuser/project-beta-automations@v2.0.0
+        with:
+          gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          organization: timescale
+          project_id: 55
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: 'Waiting for Author'
+
+  waiting-for-engineering:
+    name: Waiting for Engineering
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
+      && contains(github.event.issue.labels.*.name, 'waiting-for-author')
+    steps:
+      - name: Check if organization member
+        uses: tspascoal/get-user-teams-membership@v2
+        id: checkUserMember
+        with:
+         username: ${{ github.actor }}
+         organization: timescale
+         team: 'database-eng'
+         GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+      - name: Remove waiting-for-author label
+        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
+        with:
+          remove-labels: 'waiting-for-author, no-activity'
+          repo-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+      - name: Move to waiting for engineering column
+        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
+        with:
+          gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          organization: timescale
+          project_id: 55
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: 'Waiting for Engineering'


### PR DESCRIPTION
The jobs waiting-for-engineering and waiting-for-author are missing from GitHub workflows.
This PR will add them in our GitHub actions.