### PR TITLE
Set default statistics target to 100

### DIFF
--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -21,7 +21,7 @@ const (
 	EffectiveIOKey          = "effective_io_concurrency" // linux only
 
 	checkpointDefault           = "0.9"
-	statsTargetDefault          = "500"
+	statsTargetDefault          = "100"
 	randomPageCostDefault       = "1.1"
 	autovacuumMaxWorkersDefault = "10"
 	autovacuumNaptimeDefault    = "10"

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1420,7 +1420,7 @@ var (
 		"wal_buffers = 16MB",
 		"min_wal_size = 512MB",
 		"max_wal_size = 1GB",
-		"default_statistics_target = 500",
+		"default_statistics_target = 100",
 		"random_page_cost = 1.1",
 		"checkpoint_completion_target = 0.9",
 		fmt.Sprintf("max_connections = %d", testMaxConns),


### PR DESCRIPTION
This project set it to 500 previously, without evidences that such a high value is really needed. A PostgreSQL default of 100 will improve the planner resources usage, as well as speed up autovacuum/autoanalyze.

The user can set the higher value per-table if they need it.