### PR TITLE
Double max_locks_per_transaction

### DIFF
--- a/pkg/pgtune/misc.go
+++ b/pkg/pgtune/misc.go
@@ -72,11 +72,11 @@ func getEffectiveIOConcurrency(pgMajorVersion string) string {
 
 // maxLocksValues gives the number of locks for a power-2 memory starting
 // with sub-8GB. i.e.:
-// < 8GB = 64
-// >=8GB, < 16GB = 128
-// >=16GB, < 32GB = 256
-// >=32GB = 512
-var maxLocksValues = []string{"64", "128", "256", "512"}
+// < 8GB = 128
+// >=8GB, < 16GB = 256
+// >=16GB, < 32GB = 512
+// >=32GB = 1024
+var maxLocksValues = []string{"128", "256", "512", "1024"}
 
 // MiscLabel is the label used to refer to the miscellaneous settings group
 const MiscLabel = "miscellaneous"

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1426,9 +1426,9 @@ var (
 		fmt.Sprintf("max_connections = %d", testMaxConns),
 		"autovacuum_max_workers = 10",
 		"autovacuum_naptime = 10",
-		"max_locks_per_transaction = 64",
-		"effective_io_concurrency = 200",
 		"max_locks_per_transaction = 128",
+		"effective_io_concurrency = 200",
+		"max_locks_per_transaction = 256",
 	}
 )
 


### PR DESCRIPTION
After our last maintenance event, we have realized that current defaults do not suffice, specially for big dbs.
Given that, We're doubling what we assign in our tuner.