### PR TITLE
Bump version to v0.18.0

### DIFF
--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version is the version of this library
-	Version = "0.17.1"
+	Version = "0.18.0"
 
 	errCouldNotExecuteFmt  = "could not execute `%s --version`: %v"
 	errUnsupportedMajorFmt = "unsupported major PG version: %s"


### PR DESCRIPTION
- includes https://github.com/timescale/timescaledb-tune/pull/138