### PR TITLE
chore: Bump go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.23
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/timescale/timescaledb-tune
 
-go 1.18
+go 1.23
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
Go 1.18 is end-of-life since Feb 2023. Use a currently supported version.