### PR TITLE
test: add pg 10-18 integration tests and build infra (WIP)

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# Architecture
+
+## Project Structure
+
+```
+cmd/timescaledb-tune/    # Entry point
+pkg/pgtune/              # PostgreSQL tuning (memory, parallel, wal, misc)
+pkg/tstune/              # Orchestration (tuner, config detection, backup)
+pkg/pgutils/             # Version utilities
+internal/parse/          # Byte/time parsing
+```
+
+## Core Interfaces
+
+**Recommender** (`pkg/pgtune/tune.go`)
+- `IsAvailable()` - Can recommender run?
+- `Recommend(key)` - Get PostgreSQL-formatted value
+
+**SettingsGroup** (`pkg/pgtune/tune.go`)
+- `Label()` - Group name
+- `Keys()` - Parameter names
+- `GetRecommender(profile)` - Get recommender
+
+**SystemConfig** (`pkg/pgtune/tune.go`)
+- Wraps system resources (memory, CPUs, PG version)
+
+**Tuner** (`pkg/tstune/tuner.go`)
+- Main orchestrator, `Run()` executes workflow
+
+## Settings Groups
+
+- **Memory**: shared_buffers (25% memory), effective_cache_size (75%), maintenance_work_mem, work_mem
+- **Parallelism**: max_worker_processes, max_parallel_workers_per_gather, max_parallel_workers, timescaledb.max_background_workers
+- **WAL**: wal_buffers, min_wal_size, max_wal_size, checkpoint_timeout, wal_compression
+- **Misc**: max_connections, random_page_cost (1.1), effective_io_concurrency (200), max_locks_per_transaction, autovacuum settings
+
+## Workflow
+
+1. Init - Parse flags, detect config, get PG version
+2. Restore mode - If `--restore`, handle and exit
+3. Check shared_preload_libraries has timescaledb
+4. Tune settings - For each group: compare current vs recommended (5% tolerance), prompt/apply, backup, write
+5. Output - Show success, backup location
+
+## Parsing
+
+**Bytes** (`internal/parse/parse.go`): TB, GB, MB, kB (powers of 1024)
+**Time** (`internal/parse/time.go`): us, ms, s, min, h, d

--- a/.claude/docs/INTEGRATION_TESTING.md
+++ b/.claude/docs/INTEGRATION_TESTING.md
@@ -1,0 +1,71 @@
+# Integration Testing
+
+## Overview
+
+Tests timescaledb-tune against PostgreSQL 10-18 using TimescaleDB Docker containers.
+
+## Workflow (`.github/workflows/integration-tests.yml`)
+
+**Build job** (once):
+- Builds binary, caches based on source hash
+- Uploads artifact for test jobs
+
+**Test jobs** (9 parallel, PG 10-18):
+1. Start TimescaleDB container
+2. Run `timescaledb-tune --yes --memory=256MB --cpus=1`
+3. Show config diff
+4. Restart PostgreSQL
+5. Check logs for errors (filtering benign shutdown messages)
+
+## Test Configuration
+
+```bash
+docker run -d timescale/timescaledb:latest-pg{version}
+docker exec /tmp/timescaledb-tune --yes --memory="256MB" --cpus=1
+```
+
+**Note**: PostgreSQL 17/18 may show no config changes. This is expected - their defaults are already within 5% of recommendations for 256MB environments (tool's fudgeFactor tolerance).
+
+## Error Detection
+
+Filters benign messages:
+- `received shutdown request` - Normal shutdown
+- `terminating` - Process termination
+- `due to administrator command` - Shutdown commands
+- `background worker` - Worker lifecycle
+- `exited with exit code` - Normal exits
+
+## Triggers
+
+- Push to `main`
+- All pull requests
+- Manual (`workflow_dispatch`)
+
+## Local Testing
+
+```bash
+make build
+docker run -d --name pg-test -e POSTGRES_PASSWORD=password \
+  timescale/timescaledb:latest-pg18
+
+# Get config path
+CONFIG_PATH=$(docker exec pg-test psql -U postgres -t -c "SHOW config_file" | xargs)
+
+# Copy and run
+docker cp build/timescaledb-tune pg-test:/tmp/timescaledb-tune
+docker exec -u root -e TMPDIR=/var/lib/postgresql/data pg-test \
+  /tmp/timescaledb-tune --conf-path="${CONFIG_PATH}" --pg-version=18 --yes
+
+# Restart and check
+docker restart pg-test && sleep 3
+docker logs pg-test 2>&1 | grep -i ERROR
+
+# Cleanup
+docker rm -f pg-test
+```
+
+## Common Issues
+
+**Permission denied on backup**: Set `TMPDIR=/var/lib/postgresql/data` and use `-u root`
+
+**Grep exit code failure**: Pipeline uses `|| true` to handle no matches

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,150 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build timescaledb-tune
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      
+      - name: Cache build
+        id: cache-build
+        uses: actions/cache@v4
+        with:
+          path: build/timescaledb-tune
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod', 'go.sum', '**/*.go', 'Makefile') }}
+      
+      - name: Build binary
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: make build
+      
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: timescaledb-tune-${{ github.sha }}
+          path: build/timescaledb-tune
+          retention-days: 1
+
+  test:
+    name: Test PostgreSQL ${{ matrix.pg-version }}
+    runs-on: ubuntu-latest
+    needs: build
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        pg-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18"]
+    
+    steps:
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: timescaledb-tune-${{ github.sha }}
+      
+      - name: Make binary executable
+        run: chmod +x timescaledb-tune
+      
+      - name: Start PostgreSQL container
+        run: |
+          docker run -d \
+            --name pg-test-pg${{ matrix.pg-version }} \
+            --cpus=1 \
+            --memory=256m \
+            -e POSTGRES_PASSWORD=password \
+            -p 5432:5432 \
+            timescale/timescaledb:latest-pg${{ matrix.pg-version }}
+          
+          # Wait for PostgreSQL
+          for i in {1..30}; do
+            if docker exec pg-test-pg${{ matrix.pg-version }} pg_isready -U postgres > /dev/null 2>&1; then
+              echo "PostgreSQL ready"
+              break
+            fi
+            sleep 2
+          done
+      
+      - name: Get config and tune
+        run: |
+          set -xeu
+          # Get config path
+          CONFIG_PATH=$(docker exec pg-test-pg${{ matrix.pg-version }} psql -U postgres -t -c "SHOW config_file" | xargs)
+          
+          # Save original config
+          docker cp pg-test-pg${{ matrix.pg-version }}:${CONFIG_PATH} ./postgresql.conf.original
+          
+          # Copy binary to container
+          docker cp ./timescaledb-tune pg-test-pg${{ matrix.pg-version }}:/tmp/timescaledb-tune
+          
+          # Generate tune.conf
+          docker exec -u root -e TMPDIR=/var/lib/postgresql/data pg-test-pg${{ matrix.pg-version }} \
+             /tmp/timescaledb-tune \
+              --conf-path="${CONFIG_PATH}" \
+              --pg-version=${{ matrix.pg-version }} \
+              --pg-config=/usr/local/bin/pg_config \
+              --memory="256MB" \
+              --cpus=1 \
+              --yes
+          
+          # Copy modified config back to compare
+          docker cp pg-test-pg${{ matrix.pg-version }}:${CONFIG_PATH} ./postgresql.conf.tuned
+      
+      - name: Show tuning changes
+        run: |
+          # Display in job summary UI
+          echo "## 📊 PostgreSQL ${{ matrix.pg-version }} - Configuration Changes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`diff" >> $GITHUB_STEP_SUMMARY
+          diff -u ./postgresql.conf.original ./postgresql.conf.tuned >> $GITHUB_STEP_SUMMARY || true
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Also show in logs
+          echo "📊 Configuration changes for PostgreSQL ${{ matrix.pg-version }}:"
+          diff -u ./postgresql.conf.original ./postgresql.conf.tuned || true
+
+      - name: Restart and verify
+        run: |
+          docker restart pg-test-pg${{ matrix.pg-version }}
+          sleep 3
+          
+          # Wait for PostgreSQL
+          for i in {1..30}; do
+            if docker exec pg-test-pg${{ matrix.pg-version }} pg_isready -U postgres > /dev/null 2>&1; then
+              echo "✅ PostgreSQL restarted successfully"
+              break
+            fi
+            sleep 2
+          done
+          
+          # Check for actual errors (not shutdown/benign messages)
+          ERRORS=$(docker logs pg-test-pg${{ matrix.pg-version }} 2>&1 | \
+            grep -i "FATAL\|ERROR" | \
+            grep -v -E "(received (fast )?shutdown request|terminating|due to administrator command|background worker|database system (was interrupted|is shut down)|connected to template database|SSL error|telemetry|exited with exit code)" || true)
+          
+          if [ -n "$ERRORS" ]; then
+            echo "❌ Found errors in logs:"
+            echo "$ERRORS"
+            docker logs pg-test-pg${{ matrix.pg-version }}
+            exit 1
+          fi
+          
+          echo "✅ PostgreSQL ${{ matrix.pg-version }} - All tests passed!"
+      
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f pg-test-pg${{ matrix.pg-version }} || true
+          rm -f ./postgresql.conf.original ./postgresql.conf.tuned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Development Guide
+
+## Project Overview
+
+Go CLI tool that tunes PostgreSQL configuration for optimal TimescaleDB performance.
+
+- **Language**: Go 1.23+
+- **Version**: 0.18.1 (`pkg/tstune/tuner.go`)
+
+## Developer Preferences
+
+@~/.claude/tigerdata.md
+
+## Quick Start
+
+```bash
+# Build
+go build -v ./cmd/timescaledb-tune
+
+# Test
+go test -v ./...
+
+# Run
+./timescaledb-tune --help
+```
+
+## Key Files
+
+- `cmd/timescaledb-tune/main.go` - Entry point
+- `pkg/pgtune/` - PostgreSQL tuning logic
+- `pkg/tstune/` - TimescaleDB orchestration
+- `pkg/tstune/utils.go` - ValidPGVersions (10-18)
+
+## Important Behaviors
+
+**Settings comparison**: Uses 5% tolerance (`fudgeFactor = 0.05` in `tuner.go:66`). Settings within 5% of recommendation are not changed.
+
+**Config detection**: Platform-specific paths for `postgresql.conf`. Override with `--conf-path`.
+
+**Mocking in tests**: Uses function variables (`filepathAbsFn`, `getPGConfigVersionFn`, `osStatFn`, `execFn`).
+
+## CI/CD
+
+- **Unit tests**: `.github/workflows/go.yml`
+- **Integration tests**: `.github/workflows/integration-tests.yml` - Tests PG 10-18 in parallel
+
+## Documentation
+
+- [Architecture](.claude/docs/ARCHITECTURE.md) - System design
+- [Integration Testing](.claude/docs/INTEGRATION_TESTING.md) - Test details
+- [README.md](README.md) - User documentation

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build clean test
+
+BINARY_NAME=timescaledb-tune
+BUILD_DIR=build
+
+build:
+	@mkdir -p $(BUILD_DIR)
+	go build -v -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/timescaledb-tune/
+
+clean:
+	@rm -rf $(BUILD_DIR)
+
+test:
+	go test -v ./...


### PR DESCRIPTION
Add GitHub Actions workflow to validate timescaledb-tune against all PostgreSQL versions (10-18) using TimescaleDB containers. Tests verify that generated configurations are accepted and PostgreSQL starts without errors.

Create Makefile with build/clean/test targets for consistent build process across local development and CI environments.

Add developer documentation (AGENTS.md) with codebase structure and testing strategy, plus internal testing documentation in .claude/docs for detailed integration testing methodology.