### PR TITLE
feat: add pg_textsearch tuning support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,15 +81,19 @@ jobs:
           set -xeu
           # Get config path
           CONFIG_PATH=$(docker exec pg-test-pg${{ matrix.pg-version }} psql -U postgres -t -c "SHOW config_file" | xargs)
-          
+          # Derive a writable TMPDIR from the config directory so this works
+          # across images whose data directory layouts differ (pg18 uses
+          # /var/lib/postgresql/18/docker rather than /var/lib/postgresql/data).
+          TMPDIR_IN_CONTAINER=$(dirname "${CONFIG_PATH}")
+
           # Save original config
           docker cp pg-test-pg${{ matrix.pg-version }}:${CONFIG_PATH} ./postgresql.conf.original
-          
+
           # Copy binary to container
           docker cp ./timescaledb-tune pg-test-pg${{ matrix.pg-version }}:/tmp/timescaledb-tune
-          
+
           # Generate tune.conf
-          docker exec -u root -e TMPDIR=/var/lib/postgresql/data pg-test-pg${{ matrix.pg-version }} \
+          docker exec -u root -e TMPDIR="${TMPDIR_IN_CONTAINER}" pg-test-pg${{ matrix.pg-version }} \
              /tmp/timescaledb-tune \
               --conf-path="${CONFIG_PATH}" \
               --pg-version=${{ matrix.pg-version }} \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,10 +81,6 @@ jobs:
           set -xeu
           # Get config path
           CONFIG_PATH=$(docker exec pg-test-pg${{ matrix.pg-version }} psql -U postgres -t -c "SHOW config_file" | xargs)
-          # Derive a writable TMPDIR from the config directory so this works
-          # across images whose data directory layouts differ (pg18 uses
-          # /var/lib/postgresql/18/docker rather than /var/lib/postgresql/data).
-          TMPDIR_IN_CONTAINER=$(dirname "${CONFIG_PATH}")
 
           # Save original config
           docker cp pg-test-pg${{ matrix.pg-version }}:${CONFIG_PATH} ./postgresql.conf.original
@@ -92,8 +88,9 @@ jobs:
           # Copy binary to container
           docker cp ./timescaledb-tune pg-test-pg${{ matrix.pg-version }}:/tmp/timescaledb-tune
 
-          # Generate tune.conf
-          docker exec -u root -e TMPDIR="${TMPDIR_IN_CONTAINER}" pg-test-pg${{ matrix.pg-version }} \
+          # Generate tune.conf. Use /tmp for backups so they don't land in the
+          # Postgres data directory (its location varies across pg10-pg18 images).
+          docker exec -u root -e TMPDIR=/tmp pg-test-pg${{ matrix.pg-version }} \
              /tmp/timescaledb-tune \
               --conf-path="${CONFIG_PATH}" \
               --pg-version=${{ matrix.pg-version }} \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,6 +81,11 @@ jobs:
           set -xeu
           # Get config path
           CONFIG_PATH=$(docker exec pg-test-pg${{ matrix.pg-version }} psql -U postgres -t -c "SHOW config_file" | xargs)
+          # Derive TMPDIR from the config directory so this works across
+          # images with different data-dir layouts (pg18 uses
+          # /var/lib/postgresql/18/docker rather than /var/lib/postgresql/data).
+          # /tmp is not universally writable in these images even as root.
+          TMPDIR_IN_CONTAINER=$(dirname "${CONFIG_PATH}")
 
           # Save original config
           docker cp pg-test-pg${{ matrix.pg-version }}:${CONFIG_PATH} ./postgresql.conf.original
@@ -88,9 +93,8 @@ jobs:
           # Copy binary to container
           docker cp ./timescaledb-tune pg-test-pg${{ matrix.pg-version }}:/tmp/timescaledb-tune
 
-          # Generate tune.conf. Use /tmp for backups so they don't land in the
-          # Postgres data directory (its location varies across pg10-pg18 images).
-          docker exec -u root -e TMPDIR=/tmp pg-test-pg${{ matrix.pg-version }} \
+          # Generate tune.conf
+          docker exec -u root -e TMPDIR="${TMPDIR_IN_CONTAINER}" pg-test-pg${{ matrix.pg-version }} \
              /tmp/timescaledb-tune \
               --conf-path="${CONFIG_PATH}" \
               --pg-version=${{ matrix.pg-version }} \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ extension is appropriately installed and provides recommendations for
 memory, parallelism, WAL, and other settings.
 
 If `pg_textsearch` is listed in `shared_preload_libraries`, timescaledb-tune
-additionally recommends a value for `pg_textsearch.memory_limit` scaled to the
-host's memory. No extra flags are required.
+additionally recommends a value for `pg_textsearch.memory_limit`: total
+memory / 4 by default, or total memory / 8 under the `promscale` profile
+(which already allocates half of RAM to `shared_buffers`). No extra flags
+are required.
 
 ### Getting started
 You need the Go runtime (1.18+) installed, then simply `go install` this repo:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ It parses the existing `postgresql.conf` file to ensure that the TimescaleDB
 extension is appropriately installed and provides recommendations for
 memory, parallelism, WAL, and other settings.
 
+If `pg_textsearch` is listed in `shared_preload_libraries`, timescaledb-tune
+additionally recommends a value for `pg_textsearch.memory_limit` scaled to the
+host's memory. No extra flags are required.
+
 ### Getting started
 You need the Go runtime (1.18+) installed, then simply `go install` this repo:
 ```bash

--- a/pkg/pgtune/pg_textsearch.go
+++ b/pkg/pgtune/pg_textsearch.go
@@ -42,9 +42,10 @@ func (r *PgTextsearchRecommender) Recommend(key string) string {
 	if key != MemoryLimitKey {
 		return NoRecommendation
 	}
-	// The promscale profile sets shared_buffers to totalMemory/2 rather than
-	// the default totalMemory/4, so leave a proportionally smaller share for
-	// pg_textsearch memtables to keep overall memory usage safely bounded.
+	// memory_limit caps the DSA shared memory pg_textsearch uses for its
+	// in-memory write buffers. The promscale profile sets shared_buffers to
+	// totalMemory/2 rather than the default totalMemory/4, so leave a
+	// proportionally smaller share here to keep overall memory use bounded.
 	divisor := uint64(4)
 	if r.profile == PromscaleProfile {
 		divisor = 8
@@ -60,6 +61,10 @@ type PgTextsearchSettingsGroup struct {
 
 // Label should always return PgTextsearchLabel.
 func (sg *PgTextsearchSettingsGroup) Label() string { return PgTextsearchLabel }
+
+// DisplayLabel renders the group's heading verbatim so it appears as
+// "pg_textsearch settings recommendations" rather than "Pg_textsearch ...".
+func (sg *PgTextsearchSettingsGroup) DisplayLabel() string { return PgTextsearchLabel }
 
 // Keys should always return PgTextsearchKeys.
 func (sg *PgTextsearchSettingsGroup) Keys() []string { return PgTextsearchKeys }

--- a/pkg/pgtune/pg_textsearch.go
+++ b/pkg/pgtune/pg_textsearch.go
@@ -1,0 +1,70 @@
+package pgtune
+
+import "github.com/timescale/timescaledb-tune/internal/parse"
+
+// Keys in the conf file that are tuned related to pg_textsearch.
+const (
+	MemoryLimitKey = "pg_textsearch.memory_limit"
+)
+
+// PgTextsearchLabel is the label used to refer to the pg_textsearch settings group.
+const PgTextsearchLabel = "pg_textsearch"
+
+// PgTextsearchKeys is an array of keys tunable for pg_textsearch.
+var PgTextsearchKeys = []string{
+	MemoryLimitKey,
+}
+
+// PgTextsearchRecommender gives recommendations for pg_textsearch GUCs based on
+// total system memory and the active tuning profile. It is only available when
+// pg_textsearch appears in shared_preload_libraries.
+type PgTextsearchRecommender struct {
+	totalMemory uint64
+	profile     Profile
+	enabled     bool
+}
+
+// NewPgTextsearchRecommender returns a PgTextsearchRecommender for the given
+// total memory and profile. The enabled flag reflects whether pg_textsearch
+// was detected in shared_preload_libraries.
+func NewPgTextsearchRecommender(totalMemory uint64, profile Profile, enabled bool) *PgTextsearchRecommender {
+	return &PgTextsearchRecommender{totalMemory, profile, enabled}
+}
+
+// IsAvailable returns true only when pg_textsearch is present in
+// shared_preload_libraries.
+func (r *PgTextsearchRecommender) IsAvailable() bool {
+	return r.enabled
+}
+
+// Recommend returns the recommended PostgreSQL-formatted value for a given key.
+func (r *PgTextsearchRecommender) Recommend(key string) string {
+	if key != MemoryLimitKey {
+		return NoRecommendation
+	}
+	// The promscale profile sets shared_buffers to totalMemory/2 rather than
+	// the default totalMemory/4, so leave a proportionally smaller share for
+	// pg_textsearch memtables to keep overall memory usage safely bounded.
+	divisor := uint64(4)
+	if r.profile == PromscaleProfile {
+		divisor = 8
+	}
+	return parse.BytesToPGFormat(r.totalMemory / divisor)
+}
+
+// PgTextsearchSettingsGroup is the SettingsGroup for pg_textsearch.
+type PgTextsearchSettingsGroup struct {
+	totalMemory uint64
+	enabled     bool
+}
+
+// Label should always return PgTextsearchLabel.
+func (sg *PgTextsearchSettingsGroup) Label() string { return PgTextsearchLabel }
+
+// Keys should always return PgTextsearchKeys.
+func (sg *PgTextsearchSettingsGroup) Keys() []string { return PgTextsearchKeys }
+
+// GetRecommender returns a PgTextsearchRecommender honoring the given profile.
+func (sg *PgTextsearchSettingsGroup) GetRecommender(profile Profile) Recommender {
+	return NewPgTextsearchRecommender(sg.totalMemory, profile, sg.enabled)
+}

--- a/pkg/pgtune/pg_textsearch_test.go
+++ b/pkg/pgtune/pg_textsearch_test.go
@@ -1,0 +1,127 @@
+package pgtune
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/timescale/timescaledb-tune/internal/parse"
+)
+
+// pgTextsearchDefaultMatrix maps total memory to the expected
+// pg_textsearch.memory_limit value under the default profile (totalMemory / 4).
+var pgTextsearchDefaultMatrix = map[uint64]string{
+	2 * parse.Gigabyte:  parse.BytesToPGFormat(512 * parse.Megabyte),
+	4 * parse.Gigabyte:  parse.BytesToPGFormat(1 * parse.Gigabyte),
+	8 * parse.Gigabyte:  parse.BytesToPGFormat(2 * parse.Gigabyte),
+	16 * parse.Gigabyte: parse.BytesToPGFormat(4 * parse.Gigabyte),
+	32 * parse.Gigabyte: parse.BytesToPGFormat(8 * parse.Gigabyte),
+	64 * parse.Gigabyte: parse.BytesToPGFormat(16 * parse.Gigabyte),
+}
+
+// pgTextsearchPromscaleMatrix maps total memory to the expected
+// pg_textsearch.memory_limit value under the promscale profile (totalMemory / 8),
+// reflecting that shared_buffers takes mem/2 in that profile.
+var pgTextsearchPromscaleMatrix = map[uint64]string{
+	2 * parse.Gigabyte:  parse.BytesToPGFormat(256 * parse.Megabyte),
+	4 * parse.Gigabyte:  parse.BytesToPGFormat(512 * parse.Megabyte),
+	8 * parse.Gigabyte:  parse.BytesToPGFormat(1 * parse.Gigabyte),
+	16 * parse.Gigabyte: parse.BytesToPGFormat(2 * parse.Gigabyte),
+	32 * parse.Gigabyte: parse.BytesToPGFormat(4 * parse.Gigabyte),
+	64 * parse.Gigabyte: parse.BytesToPGFormat(8 * parse.Gigabyte),
+}
+
+func TestNewPgTextsearchRecommender(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		mem := rand.Uint64()
+		r := NewPgTextsearchRecommender(mem, DefaultProfile, true)
+		if r == nil {
+			t.Fatalf("unexpected nil recommender")
+		}
+		if got := r.totalMemory; got != mem {
+			t.Errorf("recommender has incorrect memory: got %d want %d", got, mem)
+		}
+	}
+}
+
+func TestPgTextsearchRecommenderIsAvailable(t *testing.T) {
+	cases := []struct {
+		desc    string
+		enabled bool
+		want    bool
+	}{
+		{"enabled (pg_textsearch in shared_preload_libraries)", true, true},
+		{"disabled (pg_textsearch absent)", false, false},
+	}
+	for _, c := range cases {
+		r := NewPgTextsearchRecommender(8*parse.Gigabyte, DefaultProfile, c.enabled)
+		if got := r.IsAvailable(); got != c.want {
+			t.Errorf("%s: IsAvailable() = %v, want %v", c.desc, got, c.want)
+		}
+	}
+}
+
+func TestPgTextsearchRecommenderRecommendDefault(t *testing.T) {
+	for mem, want := range pgTextsearchDefaultMatrix {
+		r := NewPgTextsearchRecommender(mem, DefaultProfile, true)
+		if got := r.Recommend(MemoryLimitKey); got != want {
+			t.Errorf("memory=%d: incorrect %s: got %s want %s", mem, MemoryLimitKey, got, want)
+		}
+	}
+}
+
+func TestPgTextsearchRecommenderRecommendPromscale(t *testing.T) {
+	for mem, want := range pgTextsearchPromscaleMatrix {
+		r := NewPgTextsearchRecommender(mem, PromscaleProfile, true)
+		if got := r.Recommend(MemoryLimitKey); got != want {
+			t.Errorf("memory=%d: incorrect %s: got %s want %s", mem, MemoryLimitKey, got, want)
+		}
+	}
+}
+
+func TestPgTextsearchRecommenderNoRecommendation(t *testing.T) {
+	r := NewPgTextsearchRecommender(8*parse.Gigabyte, DefaultProfile, true)
+	if got := r.Recommend("foo"); got != NoRecommendation {
+		t.Errorf("unexpected recommendation for unknown key: got %q", got)
+	}
+}
+
+func TestPgTextsearchSettingsGroup(t *testing.T) {
+	for mem, want := range pgTextsearchDefaultMatrix {
+		config := getDefaultTestSystemConfig(t)
+		config.Memory = mem
+		config.PgTextsearchEnabled = true
+
+		sg := GetSettingsGroup(PgTextsearchLabel, config)
+		matrix := map[string]string{MemoryLimitKey: want}
+		testSettingGroup(t, sg, DefaultProfile, matrix, PgTextsearchLabel, PgTextsearchKeys)
+	}
+}
+
+func TestPgTextsearchSettingsGroupPromscale(t *testing.T) {
+	for mem, want := range pgTextsearchPromscaleMatrix {
+		config := getDefaultTestSystemConfig(t)
+		config.Memory = mem
+		config.PgTextsearchEnabled = true
+
+		sg := GetSettingsGroup(PgTextsearchLabel, config)
+		matrix := map[string]string{MemoryLimitKey: want}
+		testSettingGroup(t, sg, PromscaleProfile, matrix, PgTextsearchLabel, PgTextsearchKeys)
+	}
+}
+
+func TestPgTextsearchSettingsGroupGatedByEnabled(t *testing.T) {
+	config := getDefaultTestSystemConfig(t)
+	config.Memory = 8 * parse.Gigabyte
+
+	config.PgTextsearchEnabled = false
+	sg := GetSettingsGroup(PgTextsearchLabel, config)
+	if sg.GetRecommender(DefaultProfile).IsAvailable() {
+		t.Errorf("recommender should be unavailable when pg_textsearch is not in shared_preload_libraries")
+	}
+
+	config.PgTextsearchEnabled = true
+	sg = GetSettingsGroup(PgTextsearchLabel, config)
+	if !sg.GetRecommender(DefaultProfile).IsAvailable() {
+		t.Errorf("recommender should be available when pg_textsearch is in shared_preload_libraries")
+	}
+}

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -72,12 +72,13 @@ type SettingsGroup interface {
 // SystemConfig represents a system's resource configuration, to be used when generating
 // recommendations for different SettingsGroups.
 type SystemConfig struct {
-	Memory         uint64
-	CPUs           int
-	PGMajorVersion string
-	WALDiskSize    uint64
-	maxConns       uint64
-	MaxBGWorkers   int
+	Memory              uint64
+	CPUs                int
+	PGMajorVersion      string
+	WALDiskSize         uint64
+	maxConns            uint64
+	MaxBGWorkers        int
+	PgTextsearchEnabled bool // true if pg_textsearch is in shared_preload_libraries
 }
 
 // NewSystemConfig returns a new SystemConfig with the given parameters.
@@ -112,6 +113,8 @@ func GetSettingsGroup(label string, config *SystemConfig) SettingsGroup {
 		return &BgwriterSettingsGroup{}
 	case label == MiscLabel:
 		return &MiscSettingsGroup{config.Memory, config.maxConns, config.PGMajorVersion}
+	case label == PgTextsearchLabel:
+		return &PgTextsearchSettingsGroup{config.Memory, config.PgTextsearchEnabled}
 	}
 	panic("unknown label: " + label)
 }

--- a/pkg/tstune/shared_preload_libs.go
+++ b/pkg/tstune/shared_preload_libs.go
@@ -5,18 +5,22 @@ import (
 	"strings"
 )
 
-const extName = "timescaledb"
+const (
+	extName             = "timescaledb"
+	pgTextsearchExtName = "pg_textsearch"
+)
 
 var sharedRegex = regexp.MustCompile("(#+?\\s*)?shared_preload_libraries = '(.*?)'.*")
 
 // sharedLibResult holds the results of extracting/parsing the shared_preload_libraries
 // line of a postgresql.conf file.
 type sharedLibResult struct {
-	idx          int    // the line index where this result was parsed
-	commented    bool   // whether the line is currently commented out (i.e., prepended by #)
-	hasTimescale bool   // whether 'timescaledb' appears in the list of libraries
-	commentGroup string // the combination of # + spaces that appear before the key / value
-	libs         string // the string value of the libraries currently set in the config file
+	idx             int    // the line index where this result was parsed
+	commented       bool   // whether the line is currently commented out (i.e., prepended by #)
+	hasTimescale    bool   // whether 'timescaledb' appears in the list of libraries
+	hasPgTextsearch bool   // whether 'pg_textsearch' appears in the list of libraries
+	commentGroup    string // the combination of # + spaces that appear before the key / value
+	libs            string // the string value of the libraries currently set in the config file
 }
 
 // parseLineForSharedLibResult attempts to parse a line of the config file by
@@ -27,10 +31,11 @@ func parseLineForSharedLibResult(line string) *sharedLibResult {
 	res := sharedRegex.FindStringSubmatch(line)
 	if len(res) > 0 {
 		return &sharedLibResult{
-			commented:    len(res[1]) > 0,
-			hasTimescale: strings.Contains(res[2], extName),
-			commentGroup: res[1],
-			libs:         res[2],
+			commented:       len(res[1]) > 0,
+			hasTimescale:    strings.Contains(res[2], extName),
+			hasPgTextsearch: strings.Contains(res[2], pgTextsearchExtName),
+			commentGroup:    res[1],
+			libs:            res[2],
 		}
 	}
 	return nil

--- a/pkg/tstune/shared_preload_libs.go
+++ b/pkg/tstune/shared_preload_libs.go
@@ -32,13 +32,33 @@ func parseLineForSharedLibResult(line string) *sharedLibResult {
 	if len(res) > 0 {
 		return &sharedLibResult{
 			commented:       len(res[1]) > 0,
-			hasTimescale:    strings.Contains(res[2], extName),
-			hasPgTextsearch: strings.Contains(res[2], pgTextsearchExtName),
+			hasTimescale:    hasLibToken(res[2], extName),
+			hasPgTextsearch: hasLibToken(res[2], pgTextsearchExtName),
 			commentGroup:    res[1],
 			libs:            res[2],
 		}
 	}
 	return nil
+}
+
+// hasLibToken reports whether libs contains name as a comma-separated token,
+// so substrings like "my_timescaledb" or "pg_textsearch_ext" don't match.
+func hasLibToken(libs, name string) bool {
+	for _, tok := range strings.Split(libs, ",") {
+		if strings.TrimSpace(tok) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// pgTextsearchDetected reports whether pg_textsearch will actually be loaded
+// once tuning completes. A commented-out shared_preload_libraries line gets
+// uncommented (with timescaledb merged in) by processSharedLibLine, so a
+// pg_textsearch entry there still counts — the caller has already gated on
+// whether the tuning flow will proceed to write those changes.
+func pgTextsearchDetected(res *sharedLibResult) bool {
+	return res != nil && res.hasPgTextsearch
 }
 
 // updateSharedLibLine takes a given line that matched the shared_preload_libraries

--- a/pkg/tstune/shared_preload_libs_test.go
+++ b/pkg/tstune/shared_preload_libs_test.go
@@ -12,9 +12,40 @@ func TestParseLineForSharedLibResult(t *testing.T) {
 			desc:  "initial config value",
 			input: "#shared_preload_libraries = ''		# (change requires restart)",
 			want: &sharedLibResult{
-				commented:    true,
-				hasTimescale: false,
-				libs:         "",
+				commented:       true,
+				hasTimescale:    false,
+				hasPgTextsearch: false,
+				libs:            "",
+			},
+		},
+		{
+			desc:  "pg_textsearch only, uncommented",
+			input: "shared_preload_libraries = 'pg_textsearch'",
+			want: &sharedLibResult{
+				commented:       false,
+				hasTimescale:    false,
+				hasPgTextsearch: true,
+				libs:            "pg_textsearch",
+			},
+		},
+		{
+			desc:  "timescaledb and pg_textsearch together",
+			input: "shared_preload_libraries = 'timescaledb,pg_textsearch'",
+			want: &sharedLibResult{
+				commented:       false,
+				hasTimescale:    true,
+				hasPgTextsearch: true,
+				libs:            "timescaledb,pg_textsearch",
+			},
+		},
+		{
+			desc:  "pg_textsearch among others, commented",
+			input: "#shared_preload_libraries = 'pg_stat_statements,pg_textsearch,timescaledb'",
+			want: &sharedLibResult{
+				commented:       true,
+				hasTimescale:    true,
+				hasPgTextsearch: true,
+				libs:            "pg_stat_statements,pg_textsearch,timescaledb",
 			},
 		},
 		{
@@ -116,6 +147,9 @@ func TestParseLineForSharedLibResult(t *testing.T) {
 			}
 			if got := res.hasTimescale; got != c.want.hasTimescale {
 				t.Errorf("%s: incorrect hasTimescale: got %v want %v", c.desc, got, c.want.hasTimescale)
+			}
+			if got := res.hasPgTextsearch; got != c.want.hasPgTextsearch {
+				t.Errorf("%s: incorrect hasPgTextsearch: got %v want %v", c.desc, got, c.want.hasPgTextsearch)
 			}
 			if got := res.libs; got != c.want.libs {
 				t.Errorf("%s: incorrect libs: got %s want %s", c.desc, got, c.want.libs)

--- a/pkg/tstune/shared_preload_libs_test.go
+++ b/pkg/tstune/shared_preload_libs_test.go
@@ -49,6 +49,26 @@ func TestParseLineForSharedLibResult(t *testing.T) {
 			},
 		},
 		{
+			desc:  "extension name as substring of another library should not match",
+			input: "shared_preload_libraries = 'my_pg_textsearch,timescaledb_toolkit'",
+			want: &sharedLibResult{
+				commented:       false,
+				hasTimescale:    false,
+				hasPgTextsearch: false,
+				libs:            "my_pg_textsearch,timescaledb_toolkit",
+			},
+		},
+		{
+			desc:  "tokens with surrounding whitespace still match",
+			input: "shared_preload_libraries = ' timescaledb , pg_textsearch '",
+			want: &sharedLibResult{
+				commented:       false,
+				hasTimescale:    true,
+				hasPgTextsearch: true,
+				libs:            " timescaledb , pg_textsearch ",
+			},
+		},
+		{
 			desc:  "extra commented out",
 			input: "###shared_preload_libraries = ''		# (change requires restart)",
 			want: &sharedLibResult{
@@ -154,6 +174,51 @@ func TestParseLineForSharedLibResult(t *testing.T) {
 			if got := res.libs; got != c.want.libs {
 				t.Errorf("%s: incorrect libs: got %s want %s", c.desc, got, c.want.libs)
 			}
+		}
+	}
+}
+
+func TestPgTextsearchDetectedFromConfigFile(t *testing.T) {
+	cases := []struct {
+		desc  string
+		lines []string
+		want  bool
+	}{
+		{
+			desc:  "no shared_preload_libraries line",
+			lines: []string{"shared_buffers = 128MB"},
+			want:  false,
+		},
+		{
+			desc:  "shared_preload_libraries without pg_textsearch",
+			lines: []string{"shared_preload_libraries = 'timescaledb'"},
+			want:  false,
+		},
+		{
+			desc:  "pg_textsearch alone",
+			lines: []string{"shared_preload_libraries = 'pg_textsearch'"},
+			want:  true,
+		},
+		{
+			desc:  "pg_textsearch alongside timescaledb",
+			lines: []string{"shared_preload_libraries = 'timescaledb,pg_textsearch'"},
+			want:  true,
+		},
+		{
+			desc:  "pg_textsearch on commented line still counts (processSharedLibLine uncomments it)",
+			lines: []string{"#shared_preload_libraries = 'pg_textsearch'"},
+			want:  true,
+		},
+		{
+			desc:  "substring match does not trigger detection",
+			lines: []string{"shared_preload_libraries = 'my_pg_textsearch'"},
+			want:  false,
+		},
+	}
+	for _, c := range cases {
+		cfs := newConfigFileStateFromSlice(t, c.lines)
+		if got := pgTextsearchDetected(cfs.sharedLibResult); got != c.want {
+			t.Errorf("%s: pgTextsearchDetected = %v, want %v", c.desc, got, c.want)
 		}
 	}
 }

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -69,14 +69,20 @@ const (
 // allows us to substitute mock versions in tests
 var filepathAbsFn = filepath.Abs
 
-// displayLabel formats a settings-group label for display in statements.
-// It capitalizes the first letter, but leaves labels that look like
-// extension/GUC names (containing '_') unchanged so "pg_textsearch" renders
-// as "pg_textsearch" rather than "Pg_textsearch".
-func displayLabel(label string) string {
-	if strings.Contains(label, "_") {
-		return label
+// displayLabeler is optionally implemented by a SettingsGroup to supply a
+// verbatim display name for the "X settings recommendations" heading when the
+// default title-casing is not appropriate (e.g. for extension/GUC names).
+type displayLabeler interface {
+	DisplayLabel() string
+}
+
+// displayLabel returns the string to show for a settings group's heading.
+// Groups may implement displayLabeler to opt out of the default title-casing.
+func displayLabel(sg pgtune.SettingsGroup) string {
+	if d, ok := sg.(displayLabeler); ok {
+		return d.DisplayLabel()
 	}
+	label := sg.Label()
 	return strings.ToUpper(label[:1]) + label[1:]
 }
 
@@ -300,9 +306,7 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 
 	// Surface pg_textsearch presence to the tuning recommenders so the
 	// dedicated settings group only runs when the extension is loaded.
-	if t.cfs.sharedLibResult != nil && t.cfs.sharedLibResult.hasPgTextsearch {
-		config.PgTextsearchEnabled = true
-	}
+	config.PgTextsearchEnabled = pgTextsearchDetected(t.cfs.sharedLibResult)
 
 	// Write backup
 	if !t.flags.DryRun {
@@ -501,7 +505,7 @@ func (t *Tuner) processSettingsGroup(sg pgtune.SettingsGroup, profile pgtune.Pro
 	quiet := t.flags.Quiet
 	if !quiet {
 		fmt.Fprintf(t.handler.out, "\n")
-		t.handler.p.Statement(fmt.Sprintf("%s settings recommendations", displayLabel(label)))
+		t.handler.p.Statement(fmt.Sprintf("%s settings recommendations", displayLabel(sg)))
 	}
 	keys := sg.Keys()
 	recommender := sg.GetRecommender(profile)

--- a/pkg/tstune/tuner.go
+++ b/pkg/tstune/tuner.go
@@ -69,6 +69,17 @@ const (
 // allows us to substitute mock versions in tests
 var filepathAbsFn = filepath.Abs
 
+// displayLabel formats a settings-group label for display in statements.
+// It capitalizes the first letter, but leaves labels that look like
+// extension/GUC names (containing '_') unchanged so "pg_textsearch" renders
+// as "pg_textsearch" rather than "Pg_textsearch".
+func displayLabel(label string) string {
+	if strings.Contains(label, "_") {
+		return label
+	}
+	return strings.ToUpper(label[:1]) + label[1:]
+}
+
 // TunerFlags are the flags that control how a Tuner object behaves when it is run.
 type TunerFlags struct {
 	Memory       string // amount of memory to base recommendations on
@@ -287,6 +298,12 @@ func (t *Tuner) Run(flags *TunerFlags, in io.Reader, out io.Writer, outErr io.Wr
 	t.cfs, err = getConfigFileState(file)
 	ifErrHandle(err)
 
+	// Surface pg_textsearch presence to the tuning recommenders so the
+	// dedicated settings group only runs when the extension is loaded.
+	if t.cfs.sharedLibResult != nil && t.cfs.sharedLibResult.hasPgTextsearch {
+		config.PgTextsearchEnabled = true
+	}
+
 	// Write backup
 	if !t.flags.DryRun {
 		backupPath, err := backup(t.cfs)
@@ -484,7 +501,7 @@ func (t *Tuner) processSettingsGroup(sg pgtune.SettingsGroup, profile pgtune.Pro
 	quiet := t.flags.Quiet
 	if !quiet {
 		fmt.Fprintf(t.handler.out, "\n")
-		t.handler.p.Statement(fmt.Sprintf("%s%s settings recommendations", strings.ToUpper(label[:1]), label[1:]))
+		t.handler.p.Statement(fmt.Sprintf("%s settings recommendations", displayLabel(label)))
 	}
 	keys := sg.Keys()
 	recommender := sg.GetRecommender(profile)
@@ -592,6 +609,7 @@ func (t *Tuner) processTunables(config *pgtune.SystemConfig, profile pgtune.Prof
 		pgtune.WALLabel,
 		pgtune.BgwriterLabel,
 		pgtune.MiscLabel,
+		pgtune.PgTextsearchLabel,
 	}
 
 	for _, label := range tunables {

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -1411,8 +1411,11 @@ func TestTunerProcessTunables(t *testing.T) {
 		checkStmt("WAL settings recommendations")
 		checkStmt("Background writer settings recommendations")
 		checkStmt("Miscellaneous settings recommendations")
+		if wantGroups > 5 {
+			checkStmt("pg_textsearch settings recommendations")
+		}
 	}
-	input := "y\ny\ny\ny\n"
+	input := "y\ny\ny\ny\ny\n"
 
 	config := getDefaultSystemConfig(t)
 	handler := setupDefaultTestIO(input)
@@ -1443,6 +1446,16 @@ func TestTunerProcessTunables(t *testing.T) {
 	tuner = newTunerWithDefaultFlags(handler, cfs)
 	tuner.processTunables(config, pgtune.PromscaleProfile)
 	check(tuner.handler, config, 4)
+
+	// pg_textsearch settings group should appear when pg_textsearch is in
+	// shared_preload_libraries (signaled via PgTextsearchEnabled on the config).
+	config = getDefaultSystemConfig(t)
+	config.PgTextsearchEnabled = true
+	handler = setupDefaultTestIO(input)
+	cfs = &configFileState{tuneParseResults: make(map[string]*tunableParseResult)}
+	tuner = newTunerWithDefaultFlags(handler, cfs)
+	tuner.processTunables(config, pgtune.DefaultProfile)
+	check(tuner.handler, config, 6)
 }
 
 var (


### PR DESCRIPTION
When `pg_textsearch` appears in `shared_preload_libraries`, the tuner now recommends a value for `pg_textsearch.memory_limit` scaled to total system memory (`totalMemory/4` for the default profile; `totalMemory/8` for `promscale`, which already reserves half of RAM for `shared_buffers`).  This GUC puts a hard cap on shared memory used by the extension.