### PR TITLE
Bump work_mem recommendation and drop Windows-specific tuning

### DIFF
--- a/pkg/pgtune/memory.go
+++ b/pkg/pgtune/memory.go
@@ -2,7 +2,6 @@ package pgtune
 
 import (
 	"math"
-	"runtime"
 
 	"github.com/timescale/timescaledb-tune/internal/parse"
 )
@@ -14,13 +13,10 @@ const (
 	MaintenanceWorkMemKey = "maintenance_work_mem"
 	WorkMemKey            = "work_mem"
 
-	// the limit is 2GB on Unix, but 2047MB on Windows, so using 2047MB is easier all around
-	maintenanceWorkMemLimit     = 2047 * parse.Megabyte
-	sharedBuffersWindows        = 512 * parse.Megabyte
-	baseConns                   = 20
-	workMemMin                  = 64 * parse.Kilobyte
-	workMemPerGigPerConn        = 6.4 * baseConns     // derived from pgtune results
-	workMemPerGigPerConnWindows = 8.53336 * baseConns // derived from pgtune results
+	maintenanceWorkMemLimit = 2047 * parse.Megabyte
+	baseConns               = 20
+	workMemMin              = 64 * parse.Kilobyte
+	workMemPerGigPerConn    = 20.0 * baseConns // targets 16MB at 2:1 RAM:CPU with default max_connections
 )
 
 // MemoryLabel is the label used to refer to the memory settings group
@@ -60,55 +56,29 @@ func (r *MemoryRecommender) IsAvailable() bool {
 // file for a given key.
 func (r *MemoryRecommender) Recommend(key string) string {
 	var val string
-	if key == SharedBuffersKey {
-		if runtime.GOOS == osWindows {
-			val = parse.BytesToPGFormat(sharedBuffersWindows)
-		} else {
-			val = parse.BytesToPGFormat(r.totalMemory / 4)
-		}
-	} else if key == EffectiveCacheKey {
+	switch key {
+	case SharedBuffersKey:
+		val = parse.BytesToPGFormat(r.totalMemory / 4)
+	case EffectiveCacheKey:
 		val = parse.BytesToPGFormat((r.totalMemory * 3) / 4)
-	} else if key == MaintenanceWorkMemKey {
+	case MaintenanceWorkMemKey:
 		temp := (float64(r.totalMemory) / float64(parse.Gigabyte)) * (128.0 * float64(parse.Megabyte))
 		if temp > maintenanceWorkMemLimit {
 			temp = maintenanceWorkMemLimit
 		}
 		val = parse.BytesToPGFormat(uint64(temp))
-	} else if key == WorkMemKey {
-		if runtime.GOOS == osWindows {
-			val = r.recommendWindows()
-		} else {
-			cpuFactor := math.Round(float64(r.cpus) / 2.0)
-			gigs := float64(r.totalMemory) / float64(parse.Gigabyte)
-			temp := uint64(gigs * (workMemPerGigPerConn * float64(parse.Megabyte) / float64(r.conns)) / cpuFactor)
-			if temp < workMemMin {
-				temp = workMemMin
-			}
-			val = parse.BytesToPGFormat(temp)
+	case WorkMemKey:
+		cpuFactor := math.Round(float64(r.cpus) / 2.0)
+		gigs := float64(r.totalMemory) / float64(parse.Gigabyte)
+		temp := uint64(gigs * (workMemPerGigPerConn * float64(parse.Megabyte) / float64(r.conns)) / cpuFactor)
+		if temp < workMemMin {
+			temp = workMemMin
 		}
-
-	} else {
+		val = parse.BytesToPGFormat(temp)
+	default:
 		val = NoRecommendation
 	}
 	return val
-}
-
-func (r *MemoryRecommender) recommendWindows() string {
-	cpuFactor := math.Round(float64(r.cpus) / 2.0)
-	var temp uint64
-
-	if r.totalMemory <= 2*parse.Gigabyte {
-		gigs := float64(r.totalMemory) / float64(parse.Gigabyte)
-		temp = uint64(gigs * (workMemPerGigPerConn * float64(parse.Megabyte) / float64(r.conns)) / cpuFactor)
-	} else {
-		base := 2.0 * workMemPerGigPerConn * float64(parse.Megabyte)
-		gigs := float64(r.totalMemory)/float64(parse.Gigabyte) - 2.0
-		temp = uint64(((gigs*(workMemPerGigPerConnWindows*float64(parse.Megabyte)) + base) / float64(r.conns)) / cpuFactor)
-	}
-	if temp < workMemMin {
-		temp = workMemMin
-	}
-	return parse.BytesToPGFormat(temp)
 }
 
 // PromscaleMemoryRecommender gives recommendations for ParallelKeys based on system resources
@@ -135,11 +105,7 @@ func (r *PromscaleMemoryRecommender) Recommend(key string) string {
 	var val string
 	switch key {
 	case SharedBuffersKey:
-		if runtime.GOOS == osWindows {
-			val = parse.BytesToPGFormat(sharedBuffersWindows)
-		} else {
-			val = parse.BytesToPGFormat(r.totalMemory / 2)
-		}
+		val = parse.BytesToPGFormat(r.totalMemory / 2)
 	default:
 		val = r.MemoryRecommender.Recommend(key)
 	}

--- a/pkg/pgtune/memory_test.go
+++ b/pkg/pgtune/memory_test.go
@@ -18,19 +18,19 @@ var defaultMemoryToBaseVals = map[uint64]map[string]uint64{
 		SharedBuffersKey:      2560 * parse.Megabyte,
 		EffectiveCacheKey:     7680 * parse.Megabyte,
 		MaintenanceWorkMemKey: 1280 * parse.Megabyte,
-		WorkMemKey:            64 * parse.Megabyte,
+		WorkMemKey:            200 * parse.Megabyte,
 	},
 	12 * parse.Gigabyte: {
 		SharedBuffersKey:      3 * parse.Gigabyte,
 		EffectiveCacheKey:     9 * parse.Gigabyte,
 		MaintenanceWorkMemKey: 1536 * parse.Megabyte,
-		WorkMemKey:            78643 * parse.Kilobyte,
+		WorkMemKey:            240 * parse.Megabyte,
 	},
 	32 * parse.Gigabyte: {
 		SharedBuffersKey:      8 * parse.Gigabyte,
 		EffectiveCacheKey:     24 * parse.Gigabyte,
 		MaintenanceWorkMemKey: maintenanceWorkMemLimit,
-		WorkMemKey:            209715 * parse.Kilobyte,
+		WorkMemKey:            640 * parse.Megabyte,
 	},
 }
 
@@ -44,19 +44,19 @@ var promscaleMemoryToBaseVals = map[uint64]map[string]uint64{
 		SharedBuffersKey:      5120 * parse.Megabyte,
 		EffectiveCacheKey:     7680 * parse.Megabyte,
 		MaintenanceWorkMemKey: 1280 * parse.Megabyte,
-		WorkMemKey:            64 * parse.Megabyte,
+		WorkMemKey:            200 * parse.Megabyte,
 	},
 	12 * parse.Gigabyte: {
 		SharedBuffersKey:      6 * parse.Gigabyte,
 		EffectiveCacheKey:     9 * parse.Gigabyte,
 		MaintenanceWorkMemKey: 1536 * parse.Megabyte,
-		WorkMemKey:            78643 * parse.Kilobyte,
+		WorkMemKey:            240 * parse.Megabyte,
 	},
 	32 * parse.Gigabyte: {
 		SharedBuffersKey:      16 * parse.Gigabyte,
 		EffectiveCacheKey:     24 * parse.Gigabyte,
 		MaintenanceWorkMemKey: maintenanceWorkMemLimit,
-		WorkMemKey:            209715 * parse.Kilobyte,
+		WorkMemKey:            640 * parse.Megabyte,
 	},
 }
 
@@ -89,21 +89,20 @@ func init() {
 				defaultMemorySettingsMatrix[mem][cpus][conns][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
 				defaultMemorySettingsMatrix[mem][cpus][conns][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
 
-				if cpus == highCPUs {
-					defaultMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] = parse.BytesToPGFormat(workMemMin)
-				} else {
-					// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
-					cpuFactor := math.Round(float64(cpus) / 2.0)
-					// Our work_mem values are derivied by a certain amount of memory lost/gained when
-					// moving away from baseConns
-					connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
-					if conns != 0 {
-						connFactor = float64(conns) / float64(baseConns)
-					}
-
-					defaultMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] =
-						parse.BytesToPGFormat(uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor))
+				// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
+				cpuFactor := math.Round(float64(cpus) / 2.0)
+				// Our work_mem values are derivied by a certain amount of memory lost/gained when
+				// moving away from baseConns
+				connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
+				if conns != 0 {
+					connFactor = float64(conns) / float64(baseConns)
 				}
+
+				wm := uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor)
+				if wm < workMemMin {
+					wm = workMemMin
+				}
+				defaultMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] = parse.BytesToPGFormat(wm)
 			}
 		}
 	}
@@ -119,21 +118,20 @@ func init() {
 				promscaleMemorySettingsMatrix[mem][cpus][conns][EffectiveCacheKey] = parse.BytesToPGFormat(baseMatrix[EffectiveCacheKey])
 				promscaleMemorySettingsMatrix[mem][cpus][conns][MaintenanceWorkMemKey] = parse.BytesToPGFormat(baseMatrix[MaintenanceWorkMemKey])
 
-				if cpus == highCPUs {
-					promscaleMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] = parse.BytesToPGFormat(workMemMin)
-				} else {
-					// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
-					cpuFactor := math.Round(float64(cpus) / 2.0)
-					// Our work_mem values are derivied by a certain amount of memory lost/gained when
-					// moving away from baseConns
-					connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
-					if conns != 0 {
-						connFactor = float64(conns) / float64(baseConns)
-					}
-
-					promscaleMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] =
-						parse.BytesToPGFormat(uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor))
+				// CPU only affects work_mem in groups of 2 (i.e. 2 and 3 CPUs are treated as the same)
+				cpuFactor := math.Round(float64(cpus) / 2.0)
+				// Our work_mem values are derivied by a certain amount of memory lost/gained when
+				// moving away from baseConns
+				connFactor := float64(MaxConnectionsDefault) / float64(baseConns)
+				if conns != 0 {
+					connFactor = float64(conns) / float64(baseConns)
 				}
+
+				wm := uint64(float64(baseMatrix[WorkMemKey]) / connFactor / cpuFactor)
+				if wm < workMemMin {
+					wm = workMemMin
+				}
+				promscaleMemorySettingsMatrix[mem][cpus][conns][WorkMemKey] = parse.BytesToPGFormat(wm)
 			}
 		}
 	}
@@ -177,108 +175,6 @@ func TestNewPromscaleMemoryRecommender(t *testing.T) {
 
 		if !r.IsAvailable() {
 			t.Errorf("unexpectedly not available")
-		}
-	}
-}
-
-func TestMemoryRecommenderRecommendWindows(t *testing.T) {
-	cases := []struct {
-		desc        string
-		totalMemory uint64
-		cpus        int
-		conns       uint64
-		want        string
-	}{
-		{
-			desc:        "1GB",
-			totalMemory: 1 * parse.Gigabyte,
-			cpus:        1,
-			conns:       baseConns,
-			want:        "6553" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "1GB, 10 conns",
-			totalMemory: 1 * parse.Gigabyte,
-			cpus:        1,
-			conns:       10,
-			want:        "13107" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "1GB, 4 cpus",
-			totalMemory: 1 * parse.Gigabyte,
-			cpus:        4,
-			conns:       baseConns,
-			want:        "3276" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "2GB",
-			totalMemory: 2 * parse.Gigabyte,
-			cpus:        1,
-			conns:       baseConns,
-			want:        "13107" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "2GB, 5 cpus",
-			totalMemory: 2 * parse.Gigabyte,
-			cpus:        5,
-			conns:       baseConns,
-			want:        "4369" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "3GB",
-			totalMemory: 3 * parse.Gigabyte,
-			cpus:        1,
-			conns:       baseConns,
-			want:        "21845" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "3GB, 3 cpus",
-			totalMemory: 3 * parse.Gigabyte,
-			cpus:        3,
-			conns:       baseConns,
-			want:        "10922" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "8GB",
-			totalMemory: 8 * parse.Gigabyte,
-			cpus:        1,
-			conns:       baseConns,
-			want:        "64" + parse.MB, // from pgtune
-		},
-		{
-			desc:        "8GB, 8 cpus",
-			totalMemory: 8 * parse.Gigabyte,
-			cpus:        8,
-			conns:       baseConns,
-			want:        "16" + parse.MB, // from pgtune
-		},
-		{
-			desc:        "16GB",
-			totalMemory: 16 * parse.Gigabyte,
-			cpus:        1,
-			conns:       baseConns,
-			want:        "135441" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "16GB, 10 cpus",
-			totalMemory: 16 * parse.Gigabyte,
-			cpus:        10,
-			conns:       baseConns,
-			want:        "27088" + parse.KB, // from pgtune
-		},
-		{
-			desc:        "1GB, 9000 cpus",
-			totalMemory: parse.Gigabyte,
-			cpus:        highCPUs,
-			conns:       baseConns,
-			want:        "64" + parse.KB,
-		},
-	}
-
-	for _, c := range cases {
-		mr := NewMemoryRecommender(c.totalMemory, c.cpus, c.conns)
-		if got := mr.recommendWindows(); got != c.want {
-			t.Errorf("%s: incorrect value: got %s want %s", c.desc, got, c.want)
 		}
 	}
 }

--- a/pkg/pgtune/tune.go
+++ b/pkg/pgtune/tune.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	osWindows                = "windows"
 	errMaxConnsTooLowFmt     = "maxConns must be 0 OR >= %d: got %d"
 	errMaxBGWorkersTooLowFmt = "maxBGWorkers must be >= %d: got %d"
 	errUnrecognizedProfile   = "unrecognized profile: %s"

--- a/pkg/tstune/tuner_test.go
+++ b/pkg/tstune/tuner_test.go
@@ -781,7 +781,7 @@ func (r *badRecommender) Recommend(string) string { return "not a number" }
 func TestCheckIfShouldShowSetting(t *testing.T) {
 	valSharedBuffers := "2GB"
 	valEffective := "6GB"
-	valWorkMem := "52428kB"
+	valWorkMem := "160MB"
 	valMaintenance := "1GB"
 	okSharedBuffers := &tunableParseResult{
 		idx:       0,
@@ -1045,13 +1045,13 @@ func TestCheckIfShouldShowSettingErr(t *testing.T) {
 var (
 	memSettingsCorrect = []string{
 		"shared_buffers = 2GB",
-		"work_mem = 26214kB",
+		"work_mem = 64MB",
 		"effective_cache_size = 6GB",
 		"maintenance_work_mem = 1GB",
 	}
 	memSettingsCommented = []string{
 		"#shared_buffers = 2GB  # should be uncommented",
-		"work_mem = 20971kB",
+		"work_mem = 64MB",
 		"effective_cache_size = 6GB",
 		"maintenance_work_mem = 1GB",
 	}
@@ -1063,13 +1063,13 @@ var (
 	}
 	memSettingsMissing = []string{
 		"shared_buffers = 2GB",
-		"work_mem = 20971kB",
+		"work_mem = 64MB",
 		// missing effective cache size
 		"maintenance_work_mem = 1GB",
 	}
 	memSettingsCommentWrong = []string{
 		"#shared_buffers = 0GB  # should be uncommented, and 2GB",
-		"work_mem = 20971kB",
+		"work_mem = 64MB",
 		"effective_cache_size = 6GB",
 		"maintenance_work_mem = 0GB  # should be non-0",
 	}
@@ -1454,7 +1454,7 @@ var (
 		"shared_buffers = 2GB",
 		"effective_cache_size = 6GB",
 		"maintenance_work_mem = 1GB",
-		"work_mem = 20971kB",
+		"work_mem = 64MB",
 		"timescaledb.max_background_workers = 16",
 		"max_worker_processes = 23",
 		"max_parallel_workers_per_gather = 2",


### PR DESCRIPTION
Increase workMemPerGigPerConn from 6.4 to 20.0 (per baseConns), so the
work_mem recommendation lands on 16MB for a 2:1 RAM:vCPU instance with
default max_connections (e.g. 8GB / 4 vCPU / 100 conns -> 16MB instead
of ~5MB). The previous value mirrored upstream pgtune; we intentionally
diverge to give a more useful default for typical TimescaleDB workloads.

Once Linux drifts from pgtune, the rationale for keeping a separate
Windows code path (sharedBuffersWindows, workMemPerGigPerConnWindows,
recommendWindows, and the GOOS branches) goes away. Drop it -- modern
64-bit Windows doesn't need the conservative piecewise formula, and
TimescaleDB isn't targeted at Windows production anyway.
