### PR TITLE
ci: derive TMPDIR from config path in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,8 +88,10 @@ jobs:
           # Copy binary to container
           docker cp ./timescaledb-tune pg-test-pg${{ matrix.pg-version }}:/tmp/timescaledb-tune
           
-          # Generate tune.conf
-          docker exec -u root -e TMPDIR=/var/lib/postgresql/data pg-test-pg${{ matrix.pg-version }} \
+          # Generate tune.conf (backup is written to TMPDIR — point it at the
+          # config's own directory so it works regardless of where PGDATA lives)
+          CONFIG_DIR=$(dirname "${CONFIG_PATH}")
+          docker exec -u root -e TMPDIR="${CONFIG_DIR}" pg-test-pg${{ matrix.pg-version }} \
              /tmp/timescaledb-tune \
               --conf-path="${CONFIG_PATH}" \
               --pg-version=${{ matrix.pg-version }} \


### PR DESCRIPTION
The PG18 timescaledb image uses /var/lib/postgresql/18/docker as PGDATA
rather than /var/lib/postgresql/data, so the hardcoded TMPDIR pointed at
a directory that didn't exist and the backup write failed. Derive it
from the config file's own directory so it works across all matrix
versions.
